### PR TITLE
feat(frontend): add validation report and data grounding to attachment menu

### DIFF
--- a/frontend/src/components/attachment/AttachmentMenu.tsx
+++ b/frontend/src/components/attachment/AttachmentMenu.tsx
@@ -1,6 +1,6 @@
 import { useCallback, useEffect, useRef, useState } from 'react';
 import useClickOutside from '../../hooks/useClickOutside';
-import { Plus, Upload, FileIcon } from '../icons/Icons';
+import { Plus, Upload, FileIcon, Check } from '../icons/Icons';
 
 interface AttachedFile {
   id: string;
@@ -16,10 +16,13 @@ function formatSize(bytes: number): string {
 
 export default function AttachmentMenu() {
   const [open, setOpen] = useState(false);
-  const [files, setFiles] = useState<AttachedFile[]>([]);
-  const [dragOver, setDragOver] = useState(false);
+  const [groundingFiles, setGroundingFiles] = useState<AttachedFile[]>([]);
+  const [contextFiles, setContextFiles] = useState<AttachedFile[]>([]);
+  const [dragOverGrounding, setDragOverGrounding] = useState(false);
+  const [dragOverContext, setDragOverContext] = useState(false);
   const ref = useRef<HTMLDivElement>(null);
-  const inputId = 'attachment-file-input';
+  const groundingInputId = 'attachment-grounding-input';
+  const contextInputId = 'attachment-context-input';
 
   const close = useCallback(() => setOpen(false), []);
   useClickOutside(ref, close);
@@ -33,69 +36,119 @@ export default function AttachmentMenu() {
     return () => document.removeEventListener('keydown', onKeyDown);
   }, [open]);
 
-  const addFiles = (list: FileList) => {
-    const next = Array.from(list).map((f) => ({
+  const makeFiles = (list: FileList): AttachedFile[] =>
+    Array.from(list).map((f) => ({
       id: `${f.name}-${f.size}-${Date.now()}`,
       name: f.name,
       size: f.size,
     }));
-    setFiles((prev) => [...prev, ...next]);
-  };
 
-  const onDrop = (e: React.DragEvent) => {
-    e.preventDefault();
-    setDragOver(false);
-    if (e.dataTransfer.files?.length) addFiles(e.dataTransfer.files);
-  };
+  const totalAttached = groundingFiles.length + contextFiles.length;
 
   return (
     <div className="attach-wrap" ref={ref}>
       <button
-        className="prompt-add"
+        className={`prompt-add${totalAttached > 0 ? ' prompt-add-active' : ''}`}
         onClick={() => setOpen((o) => !o)}
         aria-label="Add attachment"
         aria-haspopup="true"
         aria-expanded={open}
       >
         <Plus size={16} strokeWidth={2} />
+        {totalAttached > 0 && (
+          <span className="prompt-add-badge">{totalAttached}</span>
+        )}
       </button>
 
       {open && (
         <div className="attach-menu" role="region" aria-label="Attachments">
-          <label
-            htmlFor={inputId}
-            className={`attach-upload ${dragOver ? 'drag-over' : ''}`}
-            onDragOver={(e) => {
-              e.preventDefault();
-              setDragOver(true);
-            }}
-            onDragLeave={() => setDragOver(false)}
-            onDrop={onDrop}
-          >
-            <Upload />
-            {dragOver ? 'Drop files here' : 'Upload Files'}
-          </label>
 
+          {/* — Grounding section — */}
+          <div className="attach-section-label">Ground in real data</div>
+          <label
+            htmlFor={groundingInputId}
+            className={`attach-upload attach-upload-grounding${dragOverGrounding ? ' drag-over' : ''}`}
+            onDragOver={(e) => { e.preventDefault(); setDragOverGrounding(true); }}
+            onDragLeave={() => setDragOverGrounding(false)}
+            onDrop={(e) => {
+              e.preventDefault();
+              setDragOverGrounding(false);
+              if (e.dataTransfer.files?.length)
+                setGroundingFiles((p) => [...p, ...makeFiles(e.dataTransfer.files)]);
+            }}
+          >
+            <Upload size={14} />
+            {dragOverGrounding ? 'Drop to ground generation' : 'Drop CSV · XLSX · Parquet'}
+          </label>
           <input
-            id={inputId}
+            id={groundingInputId}
             type="file"
             multiple
             hidden
+            accept=".csv,.xlsx,.xls,.parquet"
             onChange={(e) => {
-              if (e.target.files?.length) addFiles(e.target.files);
+              if (e.target.files?.length)
+                setGroundingFiles((p) => [...p, ...makeFiles(e.target.files!)]);
               e.target.value = '';
             }}
           />
 
+          {groundingFiles.length > 0 && (
+            <div className="attach-list">
+              {groundingFiles.map((f) => (
+                <div key={f.id} className="attach-row attach-row-grounding">
+                  <FileIcon />
+                  <span className="attach-name">{f.name}</span>
+                  <span className="attach-grounding-badge">
+                    <Check size={9} strokeWidth={2.5} />
+                    Grounding
+                  </span>
+                  <span className="attach-size">{formatSize(f.size)}</span>
+                </div>
+              ))}
+            </div>
+          )}
+
           <div className="attach-divider" />
 
-          {files.length === 0 ? (
+          {/* — Additional context section — */}
+          <div className="attach-section-label">Additional context</div>
+          <label
+            htmlFor={contextInputId}
+            className={`attach-upload${dragOverContext ? ' drag-over' : ''}`}
+            onDragOver={(e) => { e.preventDefault(); setDragOverContext(true); }}
+            onDragLeave={() => setDragOverContext(false)}
+            onDrop={(e) => {
+              e.preventDefault();
+              setDragOverContext(false);
+              if (e.dataTransfer.files?.length)
+                setContextFiles((p) => [...p, ...makeFiles(e.dataTransfer.files)]);
+            }}
+          >
+            <Upload size={14} />
+            {dragOverContext ? 'Drop files here' : 'Upload files'}
+          </label>
+          <input
+            id={contextInputId}
+            type="file"
+            multiple
+            hidden
+            onChange={(e) => {
+              if (e.target.files?.length)
+                setContextFiles((p) => [...p, ...makeFiles(e.target.files!)]);
+              e.target.value = '';
+            }}
+          />
+
+          {contextFiles.length === 0 && groundingFiles.length === 0 && (
             <div className="attach-empty">
-              No attachments yet. Drop files above or click to browse.
+              Upload your real data above to ground synthetic generation.
             </div>
-          ) : (
+          )}
+
+          {contextFiles.length > 0 && (
             <div className="attach-list">
-              {files.map((f) => (
+              {contextFiles.map((f) => (
                 <div key={f.id} className="attach-row">
                   <FileIcon />
                   <span className="attach-name">{f.name}</span>

--- a/frontend/src/components/workspace/AssistantMessage.tsx
+++ b/frontend/src/components/workspace/AssistantMessage.tsx
@@ -2,11 +2,13 @@ import { useState } from 'react';
 import Logo from '../Logo';
 import AgentTaskList from './AgentTaskList';
 import SchemaCard from './SchemaCard';
+import ValidationReport from './ValidationReport';
 import { Download } from '../icons/Icons';
 import type { WorkspaceMessage } from '../../constants/mockWorkspace';
+import { VALIDATION_REPORT } from '../../constants/mockWorkspace';
 
 type Props = Extract<WorkspaceMessage, { role: 'assistant' }>;
-type ApprovalState = 'idle' | 'generating' | 'complete';
+type ApprovalState = 'idle' | 'generating' | 'validating' | 'complete';
 
 const wait = (ms: number) => new Promise<void>((r) => window.setTimeout(r, ms));
 
@@ -16,6 +18,8 @@ export default function AssistantMessage({ loading, plan, planText, agents, sche
   const handleApprove = async () => {
     setApproval('generating');
     await wait(2200);
+    setApproval('validating');
+    await wait(1600);
     setApproval('complete');
   };
 
@@ -65,17 +69,26 @@ export default function AssistantMessage({ loading, plan, planText, agents, sche
                     Generating dataset…
                   </div>
                 )}
-                {approval === 'complete' && (
-                  <div className="ws-download-card">
-                    <div className="ws-download-info">
-                      <span className="ws-download-filename">diabetic_cohort.csv</span>
-                      <span className="ws-download-meta">10,000 rows · CSV · 2.4 MB</span>
-                    </div>
-                    <button className="ws-download-btn">
-                      <Download size={13} />
-                      Download
-                    </button>
+                {approval === 'validating' && (
+                  <div className="ws-generating">
+                    <span className="spinner" />
+                    Running validation checks…
                   </div>
+                )}
+                {approval === 'complete' && (
+                  <>
+                    <div className="ws-download-card">
+                      <div className="ws-download-info">
+                        <span className="ws-download-filename">diabetic_cohort.csv</span>
+                        <span className="ws-download-meta">10,000 rows · CSV · 2.4 MB</span>
+                      </div>
+                      <button className="ws-download-btn">
+                        <Download size={13} />
+                        Download
+                      </button>
+                    </div>
+                    <ValidationReport report={VALIDATION_REPORT} />
+                  </>
                 )}
               </div>
             )}

--- a/frontend/src/components/workspace/ValidationReport.tsx
+++ b/frontend/src/components/workspace/ValidationReport.tsx
@@ -1,0 +1,124 @@
+import { useState } from 'react';
+import { Check, ChevronDown } from '../icons/Icons';
+import type { ValidationReport as ValidationReportType } from '../../constants/mockWorkspace';
+
+interface Props {
+  report: ValidationReportType;
+}
+
+function WarnIcon() {
+  return (
+    <svg width={11} height={11} viewBox="0 0 24 24" fill="none" stroke="currentColor"
+      strokeWidth={2.5} strokeLinecap="round" strokeLinejoin="round">
+      <path d="M10.29 3.86L1.82 18a2 2 0 0 0 1.71 3h16.94a2 2 0 0 0 1.71-3L13.71 3.86a2 2 0 0 0-3.42 0z" />
+      <line x1="12" y1="9" x2="12" y2="13" />
+      <line x1="12" y1="17" x2="12.01" y2="17" />
+    </svg>
+  );
+}
+
+export default function ValidationReport({ report }: Props) {
+  const [colsExpanded, setColsExpanded] = useState(true);
+
+  return (
+    <div className="ws-validation-card">
+      <div className="ws-validation-header">
+        <span className="ws-validation-title">Validation Report</span>
+        <span className={`ws-validation-verdict ws-validation-verdict-${report.verdictStatus}`}>
+          {report.verdictStatus === 'pass' && <Check size={11} strokeWidth={2.5} />}
+          {report.verdictStatus === 'warn' && <WarnIcon />}
+          {report.verdict}
+        </span>
+      </div>
+
+      {report.edgeCaseCoverage && (
+        <div className="ws-coverage-banner">
+          <div className="ws-coverage-top">
+            <span className="ws-coverage-label">Edge Case Coverage</span>
+            <span className="ws-coverage-pct">{report.edgeCaseCoverage.coveragePct}%</span>
+          </div>
+          <div className="ws-coverage-desc">{report.edgeCaseCoverage.description}</div>
+          <div className="ws-coverage-bar-track">
+            <div
+              className="ws-coverage-bar"
+              style={{ width: `${report.edgeCaseCoverage.coveragePct}%` }}
+            />
+          </div>
+          <div className="ws-coverage-count">
+            {report.edgeCaseCoverage.generated.toLocaleString()} of{' '}
+            {report.edgeCaseCoverage.requested.toLocaleString()} requested cases generated
+          </div>
+        </div>
+      )}
+
+      <div className="ws-validation-metrics">
+        {report.metrics.map((m) => (
+          <div key={m.label} className="ws-validation-metric">
+            <span className="ws-validation-metric-label">{m.label}</span>
+            <div className="ws-validation-bar-track">
+              <div
+                className={`ws-validation-bar ws-validation-bar-${m.status}`}
+                style={{ width: `${m.score}%` }}
+              />
+            </div>
+            <div className="ws-validation-metric-footer">
+              <span className={`ws-validation-score ws-validation-score-${m.status}`}>
+                {m.score}
+              </span>
+              <span className={`ws-validation-badge ws-validation-badge-${m.status}`}>
+                {m.status === 'pass' ? 'Pass' : m.status === 'warn' ? 'Warn' : 'Fail'}
+              </span>
+            </div>
+          </div>
+        ))}
+      </div>
+
+      <button
+        className="ws-validation-section-btn"
+        onClick={() => setColsExpanded((e) => !e)}
+        aria-expanded={colsExpanded}
+      >
+        <span>Column Fidelity</span>
+        <span className={`ws-chevron${colsExpanded ? ' ws-chevron-open' : ''}`}>
+          <ChevronDown size={12} strokeWidth={2.5} />
+        </span>
+      </button>
+
+      {colsExpanded && (
+        <div className="ws-validation-cols">
+          {report.columns.map((col) => (
+            <div key={col.column} className="ws-validation-col-row">
+              <span className="ws-validation-col-name">{col.column}</span>
+              <div className="ws-validation-mini-track">
+                <div
+                  className={`ws-validation-mini-bar ws-validation-bar-${col.status}`}
+                  style={{ width: `${col.fidelity}%` }}
+                />
+              </div>
+              <span className={`ws-validation-col-pct ws-validation-score-${col.status}`}>
+                {col.fidelity}%
+              </span>
+              <div className={`ws-validation-col-icon ws-validation-col-icon-${col.status}`}>
+                {col.status === 'pass' && <Check size={10} strokeWidth={2.5} />}
+                {col.status === 'warn' && <WarnIcon />}
+              </div>
+              {col.note && (
+                <span className="ws-validation-col-note">{col.note}</span>
+              )}
+            </div>
+          ))}
+        </div>
+      )}
+
+      <div className="ws-validation-insights">
+        <div className="ws-validation-insights-label">Key Insights</div>
+        {report.insights.map((insight, i) => (
+          <div key={i} className="ws-validation-insight">
+            <span className="ws-validation-insight-dot" />
+            <span>{insight}</span>
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/constants/mockWorkspace.ts
+++ b/frontend/src/constants/mockWorkspace.ts
@@ -1,3 +1,63 @@
+export type ValidationStatus = 'pass' | 'warn' | 'fail';
+
+export interface ValidationMetric {
+  label: string;
+  score: number;
+  status: ValidationStatus;
+}
+
+export interface ValidationColumnResult {
+  column: string;
+  fidelity: number;
+  status: ValidationStatus;
+  note?: string;
+}
+
+export interface EdgeCaseCoverage {
+  requested: number;
+  generated: number;
+  description: string;
+  coveragePct: number;
+}
+
+export interface ValidationReport {
+  verdict: string;
+  verdictStatus: ValidationStatus;
+  edgeCaseCoverage?: EdgeCaseCoverage;
+  metrics: ValidationMetric[];
+  columns: ValidationColumnResult[];
+  insights: string[];
+}
+
+export const VALIDATION_REPORT: ValidationReport = {
+  verdict: 'Ready for fine-tuning',
+  verdictStatus: 'pass',
+  edgeCaseCoverage: {
+    requested: 500,
+    generated: 482,
+    description: 'HbA1c > 12 + 3+ comorbidities',
+    coveragePct: 96.4,
+  },
+  metrics: [
+    { label: 'Realism', score: 94, status: 'pass' },
+    { label: 'Diversity', score: 87, status: 'pass' },
+    { label: 'Safety / PII', score: 100, status: 'pass' },
+  ],
+  columns: [
+    { column: 'patient_id', fidelity: 100, status: 'pass' },
+    { column: 'age', fidelity: 96, status: 'pass' },
+    { column: 'sex', fidelity: 99, status: 'pass' },
+    { column: 'hba1c', fidelity: 83, status: 'warn', note: 'Mild tail compression vs. source' },
+    { column: 'comorbidities', fidelity: 91, status: 'pass' },
+    { column: 'last_visit', fidelity: 88, status: 'pass' },
+  ],
+  insights: [
+    'hba1c shows mild tail compression — consider increasing variance in generation params',
+    'No PII detected across all 10,000 rows',
+    'Inter-column correlations preserved within 4% of source statistics',
+  ],
+};
+
 export interface SchemaRow {
   column: string;
   type: string;

--- a/frontend/src/styles/attachment.css
+++ b/frontend/src/styles/attachment.css
@@ -46,6 +46,67 @@
   color: var(--text);
 }
 
+.attach-section-label {
+  font-size: 10px;
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+  color: var(--text-dim);
+  padding: 0 2px 2px;
+}
+
+.attach-upload-grounding {
+  border-color: rgba(122, 154, 109, 0.4);
+}
+
+.attach-upload-grounding:hover {
+  border-color: var(--accent);
+  color: var(--accent);
+}
+
+.attach-upload-grounding.drag-over {
+  border-color: var(--accent);
+  background: var(--accent-soft);
+  color: var(--accent);
+}
+
+.attach-row-grounding {
+  border-color: rgba(122, 154, 109, 0.25);
+}
+
+.attach-grounding-badge {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  font-size: 10px;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+  color: var(--accent);
+  background: var(--accent-soft);
+  padding: 2px 6px;
+  border-radius: 4px;
+  flex-shrink: 0;
+}
+
+.prompt-add-active {
+  color: var(--accent);
+}
+
+.prompt-add-badge {
+  position: absolute;
+  top: -4px;
+  right: -4px;
+  width: 14px;
+  height: 14px;
+  border-radius: 50%;
+  background: var(--accent);
+  color: white;
+  font-size: 9px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-weight: 600;
+}
+
 .attach-divider {
   height: 1px;
   background: var(--border);

--- a/frontend/src/styles/landing.css
+++ b/frontend/src/styles/landing.css
@@ -62,6 +62,7 @@
 }
 
 .prompt-add {
+  position: relative;
   width: 28px;
   height: 28px;
   border-radius: 6px;

--- a/frontend/src/styles/workspace.css
+++ b/frontend/src/styles/workspace.css
@@ -537,6 +537,297 @@
   opacity: 0.88;
 }
 
+/* Validation report card */
+.ws-validation-card {
+  background: var(--surface);
+  border: 1px solid var(--border);
+  border-radius: 14px;
+  overflow: hidden;
+  margin-top: 12px;
+}
+
+.ws-validation-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 14px 18px;
+  border-bottom: 1px solid var(--border);
+}
+
+.ws-validation-title {
+  font-size: 13px;
+  font-weight: 500;
+  color: var(--text);
+}
+
+.ws-validation-verdict {
+  display: inline-flex;
+  align-items: center;
+  gap: 5px;
+  font-size: 12px;
+  font-weight: 500;
+  padding: 4px 10px;
+  border-radius: 20px;
+}
+
+.ws-validation-verdict-pass {
+  background: rgba(122, 154, 109, 0.15);
+  color: var(--accent);
+}
+
+.ws-validation-verdict-warn {
+  background: rgba(196, 146, 90, 0.15);
+  color: #c4925a;
+}
+
+.ws-validation-verdict-fail {
+  background: rgba(196, 106, 90, 0.15);
+  color: #c46a5a;
+}
+
+/* Edge case coverage banner */
+.ws-coverage-banner {
+  padding: 14px 18px;
+  border-bottom: 1px solid var(--border);
+  background: rgba(122, 154, 109, 0.06);
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.ws-coverage-top {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+}
+
+.ws-coverage-label {
+  font-size: 11px;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: var(--accent);
+  font-weight: 500;
+}
+
+.ws-coverage-pct {
+  font-family: var(--mono);
+  font-size: 18px;
+  color: var(--accent);
+  line-height: 1;
+}
+
+.ws-coverage-desc {
+  font-size: 12px;
+  color: var(--text-muted);
+  font-family: var(--mono);
+}
+
+.ws-coverage-bar-track {
+  height: 5px;
+  background: var(--bg);
+  border-radius: 3px;
+  overflow: hidden;
+}
+
+.ws-coverage-bar {
+  height: 100%;
+  border-radius: 3px;
+  background: var(--accent);
+  transition: width 0.6s ease;
+}
+
+.ws-coverage-count {
+  font-size: 11px;
+  color: var(--text-dim);
+}
+
+/* Metrics row */
+.ws-validation-metrics {
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  border-bottom: 1px solid var(--border);
+}
+
+.ws-validation-metric {
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+  padding: 16px 18px;
+  border-right: 1px solid var(--border);
+}
+
+.ws-validation-metric:last-child {
+  border-right: none;
+}
+
+.ws-validation-metric-label {
+  font-size: 11px;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: var(--text-dim);
+}
+
+.ws-validation-bar-track {
+  height: 5px;
+  background: var(--bg);
+  border-radius: 3px;
+  overflow: hidden;
+}
+
+.ws-validation-bar {
+  height: 100%;
+  border-radius: 3px;
+  transition: width 0.6s ease;
+}
+
+.ws-validation-bar-pass { background: var(--accent); }
+.ws-validation-bar-warn { background: #c4925a; }
+.ws-validation-bar-fail { background: #c46a5a; }
+
+.ws-validation-metric-footer {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+}
+
+.ws-validation-score {
+  font-size: 22px;
+  font-family: var(--mono);
+  line-height: 1;
+}
+
+.ws-validation-score-pass { color: var(--accent); }
+.ws-validation-score-warn { color: #c4925a; }
+.ws-validation-score-fail { color: #c46a5a; }
+
+.ws-validation-badge {
+  font-size: 11px;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+  font-weight: 500;
+  padding: 3px 8px;
+  border-radius: 4px;
+}
+
+.ws-validation-badge-pass { background: rgba(122, 154, 109, 0.12); color: var(--accent); }
+.ws-validation-badge-warn { background: rgba(196, 146, 90, 0.12); color: #c4925a; }
+.ws-validation-badge-fail { background: rgba(196, 106, 90, 0.12); color: #c46a5a; }
+
+/* Column fidelity section */
+.ws-validation-section-btn {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  width: 100%;
+  padding: 12px 18px;
+  font-size: 12px;
+  font-weight: 500;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+  color: var(--text-dim);
+  border-bottom: 1px solid var(--border);
+  cursor: pointer;
+  background: transparent;
+  text-align: left;
+}
+
+.ws-validation-section-btn:hover {
+  background: rgba(255,255,255,0.02);
+}
+
+.ws-validation-cols {
+  border-bottom: 1px solid var(--border);
+}
+
+.ws-validation-col-row {
+  display: grid;
+  grid-template-columns: 1.2fr 1fr 52px 20px auto;
+  align-items: center;
+  gap: 12px;
+  padding: 10px 18px;
+  border-bottom: 1px solid var(--border);
+}
+
+.ws-validation-col-row:last-child {
+  border-bottom: none;
+}
+
+.ws-validation-col-name {
+  font-family: var(--mono);
+  font-size: 12px;
+  color: var(--text-muted);
+}
+
+.ws-validation-mini-track {
+  height: 4px;
+  background: var(--bg);
+  border-radius: 2px;
+  overflow: hidden;
+}
+
+.ws-validation-mini-bar {
+  height: 100%;
+  border-radius: 2px;
+}
+
+.ws-validation-col-pct {
+  font-family: var(--mono);
+  font-size: 12px;
+  text-align: right;
+}
+
+.ws-validation-col-icon {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.ws-validation-col-icon-pass { color: var(--accent); }
+.ws-validation-col-icon-warn { color: #c4925a; }
+.ws-validation-col-icon-fail { color: #c46a5a; }
+
+.ws-validation-col-note {
+  font-size: 11px;
+  color: #c4925a;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+/* Insights */
+.ws-validation-insights {
+  padding: 14px 18px;
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.ws-validation-insights-label {
+  font-size: 11px;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: var(--text-dim);
+  margin-bottom: 2px;
+}
+
+.ws-validation-insight {
+  display: flex;
+  align-items: flex-start;
+  gap: 10px;
+  font-size: 12px;
+  color: var(--text-muted);
+  line-height: 1.5;
+}
+
+.ws-validation-insight-dot {
+  width: 5px;
+  height: 5px;
+  border-radius: 50%;
+  background: var(--text-dim);
+  flex-shrink: 0;
+  margin-top: 6px;
+}
+
 /* Follow-up input */
 .ws-followup {
   display: flex;


### PR DESCRIPTION
- Add ValidationReport component with verdict badge, 3-column metrics row
  (Realism, Diversity, Safety/PII) each with score bar, numeric score, and
  Pass/Warn/Fail badge
- Edge case coverage banner sits above metrics showing requested vs generated
  count, target description, progress bar, and coverage percentage
- Collapsible column fidelity table with per-column bars, fidelity %, and
  inline warning notes for drift (e.g. hba1c tail compression)
- Key insights section with bullet callouts beneath column table
- Add validating state to approval flow: generating → validating ("Running
  validation checks…") → complete, with ValidationReport rendered below
  download card
- Rework AttachmentMenu into two sections: "Ground in real data" (CSV / XLSX /
  Parquet only) and "Additional context"