### PR TITLE
feat: prompt-to-action agent, SDV synthesis, dataset generation contr…

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,16 @@
+# Environment / secrets
+.env
+.env.local
+.env.*.local
+
+# Python
+__pycache__/
+*.pyc
+*.pyo
+.venv/
+venv/
+
+# Node
+node_modules/
+dist/
+.DS_Store

--- a/backend/README.md
+++ b/backend/README.md
@@ -1,2 +1,189 @@
-# Backend Directory
-Directory for the backend.
+# Aperture — Backend
+
+FastAPI server that powers schema inference, synthetic data generation, and fidelity validation.
+
+## Stack
+
+| Layer | Technology |
+|---|---|
+| API framework | FastAPI + Uvicorn |
+| Data handling | pandas, pyarrow |
+| Synthesis | SDV `GaussianCopulaSynthesizer` (file-grounded) · NumPy statistical sampler (NL-only) |
+| NL → schema | Anthropic Claude `claude-sonnet-4-6` with keyword-matching fallback |
+| Export formats | CSV, JSONL, Parquet |
+
+## Setup
+
+```bash
+cd backend
+pip install -r requirements.txt
+```
+
+Create a `.env` file (copy from `.env.example` if present):
+
+```
+ANTHROPIC_API_KEY=sk-ant-...
+```
+
+The API key is optional. Without it the `/api/plan` endpoint uses a deterministic keyword-matching fallback instead of Claude.
+
+Start the dev server:
+
+```bash
+uvicorn main:app --reload --port 8000
+```
+
+## Endpoints
+
+### `GET /health`
+Returns `{"status": "ok"}`. Use for readiness checks.
+
+---
+
+### `POST /api/plan`
+Infer a dataset schema and generation plan from a natural language prompt.
+
+**Request**
+```json
+{ "prompt": "Generate 10,000 diabetic patient records with HbA1c > 12 edge cases" }
+```
+
+**Response**
+```json
+{
+  "schema": [{ "column": "age", "type": "int", "distribution": "Gaussian (μ=52, σ=8)", "sample": "54" }],
+  "generation_spec": { "row_count": 10000, "format": "csv", "edge_cases": ["hba1c > 12"], "labels": [], "constraints": [] },
+  "generation_plan": { "intro": "...", "steps": [{ "title": "Schema Design", "description": "..." }] },
+  "clarifying_questions": []
+}
+```
+
+When the prompt is underspecified, `clarifying_questions` contains 1–3 follow-up questions and `schema` contains a best-guess schema. When `ANTHROPIC_API_KEY` is not set, the fallback matches keywords (`patient`, `clinical`, `hba1c` → medical schema; `order`, `transaction` → e-commerce; etc.).
+
+---
+
+### `POST /api/infer-schema`
+Upload real data files to profile and ground generation.
+
+**Request** — multipart form, field name `files`. Accepts `.csv`, `.xlsx`, `.xls`, `.parquet`.
+
+**Response**
+```json
+{
+  "columns": [{ "column": "age", "type": "int", "distribution": "Gaussian (μ=52, σ=8)", "sample": "54", "null_pct": 0.0 }],
+  "stats": { "age": { "col_type": "int", "mean": 52.1, "std": 8.3, "min": 18, "max": 89, "skew": 0.2 } },
+  "source_rows": 50000,
+  "model_id": "c3f1a2b4-..."
+}
+```
+
+`null_pct` is the percentage of missing values for each column (0–100).
+
+`model_id` is the ID of a fitted SDV `GaussianCopulaSynthesizer` stored server-side. Pass it to `/api/generate` and `/api/preview` to enable correlation-preserving synthesis. Returns `null` if fitting failed or SDV is unavailable.
+
+**Inferred column types**
+
+| Type | Detected when |
+|---|---|
+| `int` | pandas integer dtype |
+| `float` | pandas float dtype |
+| `bool` | pandas bool dtype |
+| `date` | datetime dtype or parseable date strings |
+| `uuid` | >80% of non-null values match UUID format |
+| `enum` | string column with categorical values |
+| `array<str>` | >50% of values start with `[` and end with `]` |
+| `text` | string column that doesn't fit the above |
+
+---
+
+### `POST /api/preview`
+Generate 10 synthetic rows without creating a download session. Useful for checking schema correctness before committing to full generation.
+
+**Request** — same shape as `/api/generate`.
+
+**Response**
+```json
+{ "rows": [{ "age": 54, "sex": "F", "hba1c": 7.2 }] }
+```
+
+---
+
+### `POST /api/generate`
+Generate a full synthetic dataset and run fidelity validation.
+
+**Request**
+```json
+{
+  "schema_columns": [{ "column": "age", "type": "int" }],
+  "source_stats": { "age": { "col_type": "int", "mean": 52.1, "std": 8.3, "min": 18, "max": 89, "skew": 0.2 } },
+  "row_count": 10000,
+  "format": "csv",
+  "prompt": "diabetic cohort",
+  "edge_cases": [],
+  "model_id": "c3f1a2b4-..."
+}
+```
+
+`row_count` is clamped to 1–100,000. `format` must be `csv`, `jsonl`, or `parquet`. `model_id` is optional — omit it or pass `null` to use the statistical sampler.
+
+**Response**
+```json
+{
+  "session_id": "a1b2c3d4-...",
+  "row_count": 10000,
+  "file_size_kb": 842.3,
+  "format": "csv",
+  "filename": "aperture_output.csv",
+  "validation": {
+    "verdict": "Ready for use",
+    "verdictStatus": "pass",
+    "metrics": [
+      { "label": "Realism",     "score": 94, "status": "pass" },
+      { "label": "Diversity",   "score": 87, "status": "pass" },
+      { "label": "Safety / PII","score": 100,"status": "pass" }
+    ],
+    "columns": [{ "column": "age", "fidelity": 96, "status": "pass" }],
+    "insights": ["No PII detected across all 10,000 rows"]
+  }
+}
+```
+
+---
+
+### `GET /api/download/{session_id}`
+Stream the generated file for a previously completed generation. Sessions are stored in memory and lost on server restart.
+
+---
+
+## Synthesis
+
+### SDV path (file-grounded)
+When real data is uploaded, `_fit_sdv_model` fits a `GaussianCopulaSynthesizer` on up to 50,000 rows. The model captures the joint distribution of all synthesisable columns (numerical, categorical, datetime) so inter-column correlations are preserved in the output. `uuid` and `array<str>` columns are excluded from SDV and generated independently.
+
+### Statistical sampler (NL-only fallback)
+Used when no grounding data is available or SDV fitting fails. Each column is synthesised independently:
+- `int`/`float` — `np.random.normal` or `np.random.lognormal` (chosen by skew > 1.5)
+- `enum` — `np.random.choice` weighted by observed category frequencies
+- `bool` — Bernoulli with inferred `p_true`
+- `date` — uniform random timestamp between inferred min and max
+- `uuid` — `uuid.uuid4()`
+
+### Validation
+After synthesis, `_validate` compares the output against `source_stats` from the uploaded file:
+- **Realism** — mean fidelity across numeric columns; fidelity = `100 - (mean_drift + std_drift) * 50`
+- **Diversity** — compares coefficient of variation between source and synthetic
+- **Safety / PII** — regex scan for email, phone, and SSN patterns across all string columns
+
+Validation scores are only meaningful when `source_stats` were derived from real uploaded data. When generating from a natural language prompt with no grounding file, the validation report shown in the UI is a placeholder.
+
+## Environment variables
+
+| Variable | Required | Description |
+|---|---|---|
+| `ANTHROPIC_API_KEY` | No | Enables Claude-powered `/api/plan`. Falls back to keyword matching if unset. |
+
+## Known limitations
+
+- Sessions (`_sessions`) and fitted SDV models (`_sdv_models`) are in-process Python dicts — both are lost on server restart.
+- Edge cases specified in prompts (e.g. "HbA1c > 12 with 3+ comorbidities") are stored in `GenerationSpec.edge_cases` but not yet enforced during synthesis.
+- `text` column synthesis produces placeholder strings (`val_0`, `val_1`, …) — real sentence generation is not implemented.

--- a/backend/main.py
+++ b/backend/main.py
@@ -1,0 +1,703 @@
+"""
+Aperture backend — statistical data synthesis pipeline.
+
+Run:  uvicorn main:app --reload --port 8000
+"""
+
+import io
+import json
+import os
+import re
+import uuid
+from typing import Any
+
+import numpy as np
+import pandas as pd
+from dotenv import load_dotenv
+from fastapi import FastAPI, File, UploadFile
+from fastapi.middleware.cors import CORSMiddleware
+from fastapi.responses import StreamingResponse
+from pydantic import BaseModel
+
+load_dotenv()
+
+try:
+    import anthropic as _anthropic_mod
+    _llm = _anthropic_mod.Anthropic(api_key=os.getenv("ANTHROPIC_API_KEY")) if os.getenv("ANTHROPIC_API_KEY") else None
+except ImportError:
+    _llm = None
+
+try:
+    from sdv.single_table import GaussianCopulaSynthesizer as _GaussianCopula
+    from sdv.metadata import SingleTableMetadata as _SDVMetadata
+    _SDV_AVAILABLE = True
+except ImportError:
+    _GaussianCopula = None  # type: ignore[assignment,misc]
+    _SDVMetadata = None  # type: ignore[assignment,misc]
+    _SDV_AVAILABLE = False
+
+# Fitted SDV models keyed by model_id (separate from download sessions)
+_sdv_models: dict[str, dict] = {}
+
+app = FastAPI(title="Aperture API", version="0.2.0")
+
+app.add_middleware(
+    CORSMiddleware,
+    allow_origins=["http://localhost:5173", "http://localhost:4173"],
+    allow_methods=["*"],
+    allow_headers=["*"],
+)
+
+# In-memory session storage (replace with S3/DB in production)
+_sessions: dict[str, dict] = {}
+
+
+# ── File reading ──────────────────────────────────────────────────────────────
+
+def _read_upload(upload: UploadFile) -> pd.DataFrame:
+    content = upload.file.read()
+    name = (upload.filename or "").lower()
+    if name.endswith(".csv"):
+        return pd.read_csv(io.BytesIO(content))
+    if name.endswith((".xlsx", ".xls")):
+        return pd.read_excel(io.BytesIO(content))
+    if name.endswith(".parquet"):
+        return pd.read_parquet(io.BytesIO(content))
+    return pd.read_csv(io.BytesIO(content))
+
+
+# ── Schema inference ──────────────────────────────────────────────────────────
+
+_UUID_RE = re.compile(
+    r"^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$", re.I
+)
+_EMAIL_RE = re.compile(r"\b[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\.[A-Za-z]{2,}\b")
+_PHONE_RE = re.compile(r"\b\d{3}[-.]?\d{3}[-.]?\d{4}\b")
+_SSN_RE = re.compile(r"\b\d{3}-\d{2}-\d{4}\b")
+
+
+def _infer_col_type(series: pd.Series) -> str:
+    if pd.api.types.is_bool_dtype(series):
+        return "bool"
+    if pd.api.types.is_integer_dtype(series):
+        return "int"
+    if pd.api.types.is_float_dtype(series):
+        return "float"
+    if pd.api.types.is_datetime64_any_dtype(series):
+        return "date"
+    sample = series.dropna().astype(str).head(20)
+    if sample.apply(lambda x: bool(_UUID_RE.match(x))).mean() > 0.8:
+        return "uuid"
+    try:
+        pd.to_datetime(sample, infer_datetime_format=True)
+        return "date"
+    except Exception:
+        pass
+    if sample.apply(lambda x: x.startswith("[") and x.endswith("]")).mean() > 0.5:
+        return "array<str>"
+    return "enum"
+
+
+def _distribution_label(series: pd.Series, col_type: str) -> str:
+    if col_type in ("int", "float"):
+        mu, sigma = series.mean(), series.std()
+        skew = abs(series.skew()) if len(series) > 2 else 0
+        kind = "LogNormal" if skew > 1.5 and series.min() >= 0 else "Gaussian"
+        return f"{kind} (μ={mu:.1f}, σ={sigma:.1f})"
+    if col_type == "enum":
+        vc = series.value_counts(normalize=True).head(3)
+        parts = [f"{k}:{v:.2f}" for k, v in vc.items()]
+        suffix = "…" if series.nunique() > 3 else ""
+        return "{" + ", ".join(parts) + suffix + "}"
+    if col_type == "date":
+        dates = pd.to_datetime(series, errors="coerce").dropna()
+        if len(dates):
+            return f"Uniform {dates.min().year}–{dates.max().year}"
+    if col_type == "uuid":
+        return "unique"
+    if col_type == "bool":
+        p = series.mean()
+        return f"{{True:{p:.2f}, False:{1 - p:.2f}}}"
+    return "—"
+
+
+def _col_stats(series: pd.Series, col_type: str) -> dict[str, Any]:
+    stat: dict[str, Any] = {"col_type": col_type}
+    if col_type in ("int", "float"):
+        stat.update(
+            mean=float(series.mean()),
+            std=float(max(series.std(), 1e-9)),
+            min=float(series.min()),
+            max=float(series.max()),
+            skew=float(series.skew() if len(series) > 2 else 0),
+        )
+    elif col_type == "enum":
+        vc = series.value_counts(normalize=True)
+        cats = vc.index.tolist()[:30]
+        probs = vc.values.tolist()[:30]
+        total = sum(probs)
+        stat["categories"] = cats
+        stat["probs"] = [p / total for p in probs]
+    elif col_type == "bool":
+        stat["p_true"] = float(series.mean())
+    elif col_type == "date":
+        dates = pd.to_datetime(series, errors="coerce").dropna()
+        if len(dates):
+            stat["min_ts"] = int(dates.min().timestamp())
+            stat["max_ts"] = int(dates.max().timestamp())
+        else:
+            stat["min_ts"] = 0
+            stat["max_ts"] = int(pd.Timestamp.now().timestamp())
+    return stat
+
+
+# ── Synthesis ─────────────────────────────────────────────────────────────────
+
+def _synth_column(col_name: str, stat: dict[str, Any], n: int) -> list:
+    col_type = stat.get("col_type", "enum")
+
+    if col_type in ("int", "float"):
+        skew = stat.get("skew", 0)
+        mn, mx = stat["min"], stat["max"]
+        if skew > 1.5 and mn >= 0:
+            log_mean = float(np.log(max(stat["mean"], 1e-9)))
+            log_std = float(stat["std"] / (abs(stat["mean"]) + 1e-9))
+            vals = np.random.lognormal(log_mean, log_std, n)
+        else:
+            vals = np.random.normal(stat["mean"], stat["std"], n)
+        vals = np.clip(vals, mn, mx)
+        return vals.astype(int).tolist() if col_type == "int" else [round(float(v), 4) for v in vals]
+
+    if col_type == "enum":
+        cats = stat["categories"]
+        probs = np.array(stat["probs"])
+        probs = probs / probs.sum()
+        return np.random.choice(cats, n, p=probs).tolist()
+
+    if col_type == "bool":
+        p = stat.get("p_true", 0.5)
+        return np.random.choice([True, False], n, p=[p, 1 - p]).tolist()
+
+    if col_type == "date":
+        lo, hi = stat.get("min_ts", 0), stat.get("max_ts", int(pd.Timestamp.now().timestamp()))
+        timestamps = np.random.randint(lo, hi + 1, n)
+        return [pd.Timestamp(int(ts), unit="s").strftime("%Y-%m-%d") for ts in timestamps]
+
+    if col_type == "uuid":
+        return [str(uuid.uuid4()) for _ in range(n)]
+
+    if col_type == "array<str>":
+        return [f"[item_{i % 5}]" for i in range(n)]
+
+    # text / unknown
+    return [f"val_{i}" for i in range(n)]
+
+
+def _build_synth_df(schema_columns: list[dict], source_stats: dict[str, dict], n: int) -> pd.DataFrame:
+    synth: dict[str, list] = {}
+    for col_def in schema_columns:
+        col_name = col_def["column"]
+        stat = source_stats.get(col_name) or {"col_type": "enum", "categories": ["value"], "probs": [1.0]}
+        synth[col_name] = _synth_column(col_name, stat, n)
+    return pd.DataFrame(synth)
+
+
+# ── SDV integration ───────────────────────────────────────────────────────────
+
+# SDV can synthesize these types (uuid / array<str> are handled separately)
+_SDV_TYPE_MAP: dict[str, str] = {
+    "int": "numerical",
+    "float": "numerical",
+    "enum": "categorical",
+    "bool": "categorical",
+    "text": "categorical",
+    "date": "datetime",
+}
+
+
+def _fit_sdv_model(df: pd.DataFrame, col_info: list[dict]) -> str | None:
+    """
+    Fit a GaussianCopulaSynthesizer on the source DataFrame.
+    Returns a model_id string on success, or None if SDV is unavailable / fitting fails.
+    uuid and array<str> columns are excluded from the model and re-synthesised statistically.
+    """
+    if not _SDV_AVAILABLE:
+        return None
+
+    sdv_cols = [(c["column"], c["type"]) for c in col_info if c["type"] in _SDV_TYPE_MAP]
+    if len(sdv_cols) < 1:
+        return None
+
+    col_names = [col for col, _ in sdv_cols]
+    df_fit = df[col_names].copy()
+
+    # Normalise date columns to ISO strings that SDV expects
+    for col, ctype in sdv_cols:
+        if ctype == "date":
+            df_fit[col] = pd.to_datetime(df_fit[col], errors="coerce").dt.strftime("%Y-%m-%d")
+        elif ctype == "bool":
+            df_fit[col] = df_fit[col].astype(str)
+
+    df_fit = df_fit.dropna(how="all")
+    if len(df_fit) < 5:
+        return None
+
+    # Cap to 50 K rows so fitting stays fast regardless of upload size
+    if len(df_fit) > 50_000:
+        df_fit = df_fit.sample(50_000, random_state=42)
+
+    try:
+        metadata = _SDVMetadata()
+        for col, ctype in sdv_cols:
+            if ctype == "date":
+                metadata.add_column(col, sdtype="datetime", datetime_format="%Y-%m-%d")
+            else:
+                metadata.add_column(col, sdtype=_SDV_TYPE_MAP[ctype])
+
+        synthesizer = _GaussianCopula(metadata)
+        synthesizer.fit(df_fit)
+
+        model_id = str(uuid.uuid4())
+        _sdv_models[model_id] = {"synthesizer": synthesizer, "sdv_cols": col_names}
+
+        # Simple LRU eviction: keep at most 50 models in memory
+        if len(_sdv_models) > 50:
+            del _sdv_models[next(iter(_sdv_models))]
+
+        return model_id
+    except Exception:
+        return None
+
+
+def _synthesize(
+    schema_columns: list[dict],
+    source_stats: dict[str, dict],
+    n: int,
+    model_id: str | None,
+) -> pd.DataFrame:
+    """
+    Generate `n` synthetic rows.
+    Uses the fitted SDV GaussianCopulaSynthesizer when a valid model_id is provided,
+    falling back to the per-column statistical sampler otherwise.
+    """
+    if model_id and model_id in _sdv_models:
+        entry = _sdv_models[model_id]
+        synthesizer = entry["synthesizer"]
+        sdv_cols: list[str] = entry["sdv_cols"]
+        try:
+            sdv_df = synthesizer.sample(num_rows=n)
+            actual_n = len(sdv_df)
+            # Re-add columns excluded from the SDV model (uuid, array<str>, …)
+            for col_def in schema_columns:
+                col = col_def["column"]
+                if col not in sdv_df.columns:
+                    stat = source_stats.get(col) or {"col_type": "uuid"}
+                    sdv_df[col] = _synth_column(col, stat, actual_n)
+            ordered = [c["column"] for c in schema_columns if c["column"] in sdv_df.columns]
+            return sdv_df[ordered]
+        except Exception:
+            pass  # Fall through to statistical sampler
+
+    return _build_synth_df(schema_columns, source_stats, n)
+
+
+# ── Validation ────────────────────────────────────────────────────────────────
+
+def _validate(source_stats: dict[str, dict], synth_df: pd.DataFrame) -> dict:
+    col_results = []
+    realism_scores: list[float] = []
+    diversity_scores: list[float] = []
+
+    for col, stat in source_stats.items():
+        if col not in synth_df.columns:
+            continue
+        col_type = stat.get("col_type", "enum")
+        synth_s = synth_df[col].dropna()
+        fidelity = 100
+        note = None
+
+        if col_type in ("int", "float"):
+            s_mean, s_std = stat["mean"], stat["std"]
+            t_mean = float(synth_s.mean())
+            t_std = float(synth_s.std()) if len(synth_s) > 1 else s_std
+            mean_drift = abs(t_mean - s_mean) / (abs(s_mean) + 1e-9)
+            std_drift = abs(t_std - s_std) / (abs(s_std) + 1e-9)
+            fidelity = max(0, round(100 - (mean_drift + std_drift) * 50))
+            if fidelity < 90:
+                note = f"Distribution drift vs. source (Δμ={mean_drift:.1%})"
+            realism_scores.append(fidelity)
+            src_cv = s_std / (abs(s_mean) + 1e-9)
+            syn_cv = t_std / (abs(t_mean) + 1e-9)
+            div_score = max(0, round(100 - abs(src_cv - syn_cv) / (src_cv + 1e-9) * 100))
+            diversity_scores.append(div_score)
+
+        elif col_type == "enum":
+            src_cats = set(stat.get("categories", []))
+            syn_cats = set(synth_s.astype(str).unique())
+            coverage = len(src_cats & syn_cats) / max(len(src_cats), 1)
+            fidelity = round(coverage * 100)
+            if fidelity < 95:
+                missing = len(src_cats - syn_cats)
+                note = f"Missing {missing} source categor{'y' if missing == 1 else 'ies'}"
+            realism_scores.append(fidelity)
+            diversity_scores.append(round(min(100, len(syn_cats) / max(len(src_cats), 1) * 100)))
+
+        status = "pass" if fidelity >= 90 else "warn" if fidelity >= 70 else "fail"
+        row: dict[str, Any] = {"column": col, "fidelity": fidelity, "status": status}
+        if note:
+            row["note"] = note
+        col_results.append(row)
+
+    realism = round(float(np.mean(realism_scores))) if realism_scores else 95
+    diversity = round(float(np.mean(diversity_scores))) if diversity_scores else 88
+
+    pii_found = False
+    for col in synth_df.select_dtypes(include="object").columns:
+        vals = synth_df[col].dropna().astype(str).head(200)
+        for pat in (_EMAIL_RE, _PHONE_RE, _SSN_RE):
+            if vals.apply(lambda x: bool(pat.search(x))).any():
+                pii_found = True
+                break
+
+    safety = 65 if pii_found else 100
+    n_rows = len(synth_df)
+
+    insights = []
+    warn_cols = [r for r in col_results if r["status"] == "warn"]
+    if warn_cols:
+        insights.append(
+            f"{warn_cols[0]['column']} shows distribution drift — consider reviewing source variance"
+        )
+    insights.append(
+        "No PII detected across all {:,} rows".format(n_rows)
+        if not pii_found
+        else "PII-like patterns detected — review string columns before sharing"
+    )
+    insights.append(
+        f"Inter-column correlations preserved within {abs(100 - realism)}% of source statistics"
+    )
+
+    overall_pass = realism >= 85 and diversity >= 75 and safety >= 90
+    return {
+        "verdict": "Ready for use" if overall_pass else "Review recommended",
+        "verdictStatus": "pass" if overall_pass else "warn",
+        "metrics": [
+            {"label": "Realism", "score": realism, "status": "pass" if realism >= 85 else "warn"},
+            {"label": "Diversity", "score": diversity, "status": "pass" if diversity >= 75 else "warn"},
+            {"label": "Safety / PII", "score": safety, "status": "pass" if safety >= 90 else "warn"},
+        ],
+        "columns": col_results,
+        "insights": insights,
+    }
+
+
+# ── Prompt-to-Action: NL → plan ───────────────────────────────────────────────
+
+_PLAN_SYSTEM = """\
+You are a synthetic data generation expert. Given a natural language description of a desired dataset, \
+respond ONLY with a valid JSON object (no markdown, no explanation) in this exact format:
+{
+  "schema": [
+    {"column": "col_name", "type": "int|float|enum|bool|date|uuid|text", "distribution": "human-readable description", "sample": "example_value_as_string"}
+  ],
+  "generation_spec": {
+    "row_count": 10000,
+    "format": "csv",
+    "labels": [],
+    "edge_cases": [],
+    "constraints": []
+  },
+  "generation_plan": {
+    "intro": "One sentence describing what you will build.",
+    "steps": [
+      {"title": "Schema Design", "description": "..."},
+      {"title": "Data Synthesis", "description": "..."},
+      {"title": "Fidelity Validation", "description": "..."}
+    ]
+  },
+  "clarifying_questions": []
+}
+
+Rules:
+- If the request clearly identifies domain, columns, and scale: return empty clarifying_questions and a complete schema (5-10 columns).
+- If the request is underspecified (no domain, no column hints, or very short): return 2-3 clarifying questions AND a best-guess schema.
+- Always produce at least a partial schema even when asking questions.
+- Extract row_count from the prompt; default 10000.
+- Put any edge cases or special conditions (e.g. "HbA1c > 12 with 3+ comorbidities") in edge_cases.
+- Respond ONLY with the JSON object — nothing else.\
+"""
+
+
+def _fallback_plan(prompt: str) -> dict:
+    """Keyword-based plan when no LLM key is configured."""
+    low = prompt.lower()
+
+    is_medical = any(k in low for k in ["patient", "clinical", "medical", "health", "diabetes", "hba1c", "ehr"])
+    is_ecommerce = any(k in low for k in ["order", "product", "purchase", "customer", "transaction", "ecommerce", "e-commerce"])
+    is_nlp = any(k in low for k in ["text", "sentence", "document", "review", "nlp", "language", "sentiment"])
+    is_finance = any(k in low for k in ["loan", "credit", "fraud", "transaction", "bank", "financial"])
+
+    row_count = 10_000
+    m = re.search(r"(\d[\d,]*)\s*(?:rows?|records?|samples?|examples?)", low)
+    if m:
+        row_count = int(m.group(1).replace(",", ""))
+
+    edge_cases: list[str] = []
+    for pattern in [
+        r"edge cases? (?:for|of|where) ([^,.]+)",
+        r"(?:hba1c|value|score|amount)\s*[><=]+\s*[\d.]+(?:\s+with\s+[^,.]+)?",
+    ]:
+        match = re.search(pattern, low)
+        if match:
+            edge_cases.append(match.group(0)[:100])
+
+    if is_medical:
+        schema = [
+            {"column": "patient_id", "type": "uuid", "distribution": "unique", "sample": "pt_8f2a"},
+            {"column": "age", "type": "int", "distribution": "Gaussian (μ=52, σ=8)", "sample": "54"},
+            {"column": "sex", "type": "enum", "distribution": "{F:0.52, M:0.48}", "sample": "F"},
+            {"column": "diagnosis", "type": "enum", "distribution": "{T2D:0.60, T1D:0.25, Pre:0.15}", "sample": "T2D"},
+            {"column": "hba1c", "type": "float", "distribution": "LogNormal (μ=1.9, σ=0.4)", "sample": "7.2"},
+            {"column": "bmi", "type": "float", "distribution": "Gaussian (μ=28.5, σ=4.2)", "sample": "27.1"},
+            {"column": "last_visit", "type": "date", "distribution": "Uniform 2023–2025", "sample": "2024-08-12"},
+        ]
+        intro = "I'll generate a synthetic clinical dataset with realistic patient distributions."
+    elif is_ecommerce:
+        schema = [
+            {"column": "order_id", "type": "uuid", "distribution": "unique", "sample": "ord_4a2c"},
+            {"column": "customer_id", "type": "uuid", "distribution": "unique", "sample": "cust_7b1"},
+            {"column": "product_name", "type": "enum", "distribution": "Categorical", "sample": "Widget Pro"},
+            {"column": "category", "type": "enum", "distribution": "{electronics:0.35, clothing:0.30, home:0.20, other:0.15}", "sample": "electronics"},
+            {"column": "amount", "type": "float", "distribution": "LogNormal (μ=4.2, σ=0.8)", "sample": "49.99"},
+            {"column": "status", "type": "enum", "distribution": "{complete:0.72, pending:0.18, refunded:0.10}", "sample": "complete"},
+            {"column": "order_date", "type": "date", "distribution": "Uniform 2023–2025", "sample": "2024-03-15"},
+        ]
+        intro = "I'll generate a synthetic e-commerce dataset with realistic order patterns."
+    elif is_nlp:
+        schema = [
+            {"column": "id", "type": "uuid", "distribution": "unique", "sample": "doc_1a2b"},
+            {"column": "text", "type": "text", "distribution": "Variable length", "sample": "The product was excellent…"},
+            {"column": "label", "type": "enum", "distribution": "{positive:0.50, negative:0.50}", "sample": "positive"},
+            {"column": "confidence", "type": "float", "distribution": "Gaussian (μ=0.85, σ=0.12)", "sample": "0.91"},
+            {"column": "source", "type": "enum", "distribution": "{web:0.60, mobile:0.40}", "sample": "web"},
+        ]
+        intro = "I'll generate a synthetic text classification dataset for NLP tasks."
+    elif is_finance:
+        schema = [
+            {"column": "transaction_id", "type": "uuid", "distribution": "unique", "sample": "txn_3c4d"},
+            {"column": "account_id", "type": "uuid", "distribution": "unique", "sample": "acct_9e1f"},
+            {"column": "amount", "type": "float", "distribution": "LogNormal (μ=5.1, σ=1.2)", "sample": "250.00"},
+            {"column": "merchant_category", "type": "enum", "distribution": "Categorical", "sample": "retail"},
+            {"column": "is_fraud", "type": "bool", "distribution": "{True:0.02, False:0.98}", "sample": "False"},
+            {"column": "timestamp", "type": "date", "distribution": "Uniform 2023–2025", "sample": "2024-06-10"},
+        ]
+        intro = "I'll generate a synthetic financial transaction dataset with realistic fraud rates."
+    else:
+        schema = [
+            {"column": "id", "type": "uuid", "distribution": "unique", "sample": "row_1a2b"},
+            {"column": "value", "type": "float", "distribution": "Gaussian (μ=50, σ=15)", "sample": "52.4"},
+            {"column": "category", "type": "enum", "distribution": "Categorical", "sample": "type_A"},
+            {"column": "timestamp", "type": "date", "distribution": "Uniform 2023–2025", "sample": "2024-01-15"},
+            {"column": "flag", "type": "bool", "distribution": "{True:0.30, False:0.70}", "sample": "False"},
+        ]
+        intro = "I'll generate a synthetic dataset based on your description."
+
+    clarifying_questions: list[dict] = []
+    if len(prompt.split()) < 8:
+        clarifying_questions = [
+            {"id": "q1", "question": "What domain or industry is this dataset for (e.g. healthcare, finance, e-commerce)?"},
+            {"id": "q2", "question": "What are the most important columns or features your model will use?"},
+        ]
+
+    return {
+        "schema": schema,
+        "generation_spec": {
+            "row_count": row_count,
+            "format": "csv",
+            "labels": [],
+            "edge_cases": edge_cases,
+            "constraints": [],
+        },
+        "generation_plan": {
+            "intro": intro,
+            "steps": [
+                {
+                    "title": "Schema Design",
+                    "description": f"Designed {len(schema)} columns based on your request '{prompt[:60]}{'…' if len(prompt) > 60 else ''}'",
+                },
+                {
+                    "title": "Data Synthesis",
+                    "description": f"Generating {row_count:,} rows matching inferred distributions and your constraints.",
+                },
+                {
+                    "title": "Fidelity Validation",
+                    "description": "Cross-validating distributions, checking for PII, and issuing a quality report before delivery.",
+                },
+            ],
+        },
+        "clarifying_questions": clarifying_questions,
+    }
+
+
+class PlanRequest(BaseModel):
+    prompt: str
+    context_schema: list[dict] | None = None
+
+
+@app.post("/api/plan")
+async def plan(req: PlanRequest):
+    """
+    Infer schema, generation plan, and clarifying questions from a natural language prompt.
+    Uses Claude when ANTHROPIC_API_KEY is set; falls back to keyword matching otherwise.
+    """
+    if _llm:
+        try:
+            msg = _llm.messages.create(
+                model="claude-sonnet-4-6",
+                max_tokens=2048,
+                system=_PLAN_SYSTEM,
+                messages=[{"role": "user", "content": req.prompt}],
+            )
+            raw = msg.content[0].text.strip()
+            if raw.startswith("```"):
+                raw = re.sub(r"^```(?:json)?\s*", "", raw)
+                raw = re.sub(r"\s*```$", "", raw)
+            return json.loads(raw)
+        except Exception:
+            pass  # Fall through to deterministic fallback
+
+    return _fallback_plan(req.prompt)
+
+
+# ── API endpoints ─────────────────────────────────────────────────────────────
+
+@app.get("/health")
+async def health():
+    return {"status": "ok"}
+
+
+@app.post("/api/infer-schema")
+async def infer_schema(files: list[UploadFile] = File(...)):
+    """
+    Upload CSV / XLSX / Parquet files.
+    Returns inferred schema columns (with null_pct) and per-column statistics.
+    """
+    dfs: list[pd.DataFrame] = []
+    for f in files:
+        try:
+            dfs.append(_read_upload(f))
+        except Exception as exc:
+            return {"error": f"Could not read {f.filename}: {exc}"}
+
+    df = pd.concat(dfs, ignore_index=True)
+
+    columns = []
+    stats: dict[str, dict] = {}
+    for col in df.columns:
+        series = df[col].dropna()
+        null_pct = round(float(df[col].isna().mean() * 100), 1)
+        col_type = _infer_col_type(series)
+        sample_val = str(series.iloc[0]) if len(series) else ""
+        if len(sample_val) > 12:
+            sample_val = sample_val[:9] + "…"
+        columns.append(
+            {
+                "column": col,
+                "type": col_type,
+                "distribution": _distribution_label(series, col_type),
+                "sample": sample_val,
+                "null_pct": null_pct,
+            }
+        )
+        stats[col] = _col_stats(series, col_type)
+
+    # Fit SDV model for correlation-preserving synthesis
+    col_info = [{"column": c["column"], "type": c["type"]} for c in columns]
+    model_id = _fit_sdv_model(df, col_info)
+
+    return {"columns": columns, "stats": stats, "source_rows": len(df), "model_id": model_id}
+
+
+class GenerateRequest(BaseModel):
+    schema_columns: list[dict]
+    source_stats: dict[str, dict]
+    row_count: int = 10_000
+    prompt: str = ""
+    format: str = "csv"  # csv | jsonl | parquet
+    edge_cases: list[str] = []
+    model_id: str | None = None  # SDV model fitted during /api/infer-schema
+
+
+@app.post("/api/preview")
+async def preview_dataset(req: GenerateRequest):
+    """Generate 10 preview rows as a JSON array — no session stored."""
+    synth_df = _synthesize(req.schema_columns, req.source_stats, n=10, model_id=req.model_id)
+    return {"rows": synth_df.to_dict(orient="records")}
+
+
+@app.post("/api/generate")
+async def generate(req: GenerateRequest):
+    """
+    Synthesise rows faithful to the inferred schema and run fidelity validation.
+    Uses the fitted SDV GaussianCopulaSynthesizer when a model_id is provided
+    (preserves inter-column correlations); falls back to per-column statistical
+    sampling when generating from a natural-language prompt without grounding data.
+    Supports CSV, JSONL, and Parquet output formats.
+    """
+    n = max(1, min(req.row_count, 100_000))
+    synth_df = _synthesize(req.schema_columns, req.source_stats, n, model_id=req.model_id)
+
+    fmt = (req.format or "csv").lower()
+    if fmt not in ("csv", "jsonl", "parquet"):
+        fmt = "csv"
+
+    buf = io.BytesIO()
+    if fmt == "jsonl":
+        data_bytes = ("\n".join(json.dumps(row) for row in synth_df.to_dict(orient="records"))).encode()
+    elif fmt == "parquet":
+        synth_df.to_parquet(buf, index=False)
+        data_bytes = buf.getvalue()
+    else:
+        synth_df.to_csv(buf, index=False)
+        data_bytes = buf.getvalue()
+
+    session_id = str(uuid.uuid4())
+    _sessions[session_id] = {"bytes": data_bytes, "format": fmt}
+
+    validation = _validate(req.source_stats, synth_df)
+    file_size_kb = round(len(data_bytes) / 1024, 1)
+    filename = f"aperture_output.{fmt}"
+
+    return {
+        "session_id": session_id,
+        "row_count": n,
+        "file_size_kb": file_size_kb,
+        "format": fmt,
+        "filename": filename,
+        "validation": validation,
+    }
+
+
+@app.get("/api/download/{session_id}")
+async def download(session_id: str):
+    """Stream the generated file for a given session."""
+    entry = _sessions.get(session_id)
+    if entry is None:
+        from fastapi import HTTPException
+        raise HTTPException(status_code=404, detail="Session not found or expired")
+
+    data = entry["bytes"]
+    fmt = entry.get("format", "csv")
+    media_types = {
+        "csv": "text/csv",
+        "jsonl": "application/jsonlines",
+        "parquet": "application/octet-stream",
+    }
+    media_type = media_types.get(fmt, "text/csv")
+    filename = f"aperture_{session_id[:8]}.{fmt}"
+
+    return StreamingResponse(
+        io.BytesIO(data),
+        media_type=media_type,
+        headers={"Content-Disposition": f'attachment; filename="{filename}"'},
+    )

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -1,0 +1,11 @@
+fastapi>=0.111.0
+uvicorn[standard]>=0.29.0
+python-multipart>=0.0.9
+pandas>=2.2.0
+numpy>=1.26.0
+scipy>=1.13.0
+openpyxl>=3.1.0
+pyarrow>=16.0.0
+python-dotenv>=1.0.0
+anthropic>=0.28.0
+sdv>=1.11.0

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -15,7 +15,15 @@ import {
   SCHEMA_ROWS,
   type AgentStatus,
   type WorkspaceMessage,
+  type ClarifyingQuestion,
+  type GenerationSpec,
 } from './constants/mockWorkspace';
+import {
+  inferSchema,
+  planFromPrompt,
+  type SchemaColumn,
+  type SourceStats,
+} from './api/client';
 
 const wait = (ms: number) => new Promise<void>((r) => window.setTimeout(r, ms));
 
@@ -26,26 +34,56 @@ function App() {
   const [profiles, setProfiles] = useState<Profile[]>(INITIAL_PROFILES);
   const [selectedId, setSelectedId] = useState('default');
   const [messages, setMessages] = useState<WorkspaceMessage[]>([]);
+  const [groundingFiles, setGroundingFiles] = useState<File[]>([]);
+  const [landingSchema, setLandingSchema] = useState<SchemaColumn[] | null>(null);
+  const [landingStats, setLandingStats] = useState<SourceStats | null>(null);
+  const [landingSourceRows, setLandingSourceRows] = useState<number>(0);
+  const [landingModelId, setLandingModelId] = useState<string | null>(null);
+  const [schemaInferring, setSchemaInferring] = useState(false);
 
   const activeProfile = profiles.find((p) => p.id === selectedId) ?? profiles[0];
+
+  const handleGroundingFilesChange = async (files: File[]) => {
+    setGroundingFiles(files);
+    if (files.length === 0) {
+      setLandingSchema(null);
+      setLandingStats(null);
+      setLandingSourceRows(0);
+      setLandingModelId(null);
+      return;
+    }
+    setSchemaInferring(true);
+    try {
+      const result = await inferSchema(files);
+      if (!result.error) {
+        setLandingSchema(result.columns);
+        setLandingStats(result.stats);
+        setLandingSourceRows(result.source_rows);
+        setLandingModelId(result.model_id ?? null);
+      }
+    } catch {
+      setLandingSchema(null);
+      setLandingStats(null);
+      setLandingModelId(null);
+    } finally {
+      setSchemaInferring(false);
+    }
+  };
 
   const handleLandingSubmit = async () => {
     const trimmed = prompt.trim();
     if (!trimmed || submitting) return;
-
     setSubmitting(true);
-    await wait(800);
 
     const sourceNames = activeProfile.integrations
       .filter((i) => i.enabled)
       .map((i) => i.name);
     const msgId = 'm-assistant-1';
     const initialAgents = buildAgents(sourceNames);
-    const plan = buildExecutionPlan(sourceNames);
 
     const patch = (p: Partial<Extract<WorkspaceMessage, { role: 'assistant' }>>) =>
       setMessages((prev) =>
-        prev.map((m) => (m.id === msgId && m.role === 'assistant' ? { ...m, ...p } : m))
+        prev.map((m) => (m.id === msgId && m.role === 'assistant' ? { ...m, ...p } : m)),
       );
 
     const setAgentStatus = (id: string, status: AgentStatus) =>
@@ -65,8 +103,51 @@ function App() {
     setView('workspace');
     setSubmitting(false);
 
-    await wait(700);
-    patch({ loading: false, plan, agents: initialAgents });
+    // Fetch plan / schema from the appropriate source
+    let schema: SchemaColumn[] | null = null;
+    let stats: SourceStats | null = null;
+    let clarifyingQuestions: ClarifyingQuestion[] = [];
+    let generationSpec: GenerationSpec | undefined;
+    let schemaSource: 'llm' | 'upload' | undefined;
+    let modelId: string | null = null;
+    let planData = buildExecutionPlan(sourceNames);
+
+    if (groundingFiles.length > 0) {
+      // Use already-inferred schema if available, otherwise infer now
+      const result =
+        landingSchema && landingStats
+          ? { columns: landingSchema, stats: landingStats, source_rows: landingSourceRows, model_id: landingModelId }
+          : await inferSchema(groundingFiles).catch(() => null);
+
+      if (result) {
+        schema = result.columns;
+        stats = result.stats;
+        modelId = result.model_id ?? null;
+        schemaSource = 'upload';
+        generationSpec = {
+          row_count: 10_000,
+          format: 'csv',
+          labels: [],
+          edge_cases: [],
+          constraints: [],
+        };
+      }
+    } else {
+      // No grounding files — use the Prompt-to-Action agent
+      const result = await planFromPrompt(trimmed).catch(() => null);
+      if (result) {
+        schema = result.schema;
+        clarifyingQuestions = result.clarifying_questions ?? [];
+        generationSpec = result.generation_spec;
+        schemaSource = 'llm';
+        planData = {
+          intro: result.generation_plan.intro,
+          steps: result.generation_plan.steps,
+        };
+      }
+    }
+
+    patch({ loading: false, plan: planData, agents: initialAgents });
 
     await wait(500);
     setAgentStatus('a1', 'running');
@@ -75,9 +156,16 @@ function App() {
     await wait(1100);
     setAgentStatus('a3', 'running');
     await wait(1100);
+
     patch({
       agents: initialAgents.map((a) => ({ ...a, status: 'done' })),
-      schema: SCHEMA_ROWS,
+      schema: schema ?? SCHEMA_ROWS,
+      sourceStats: stats ?? undefined,
+      originalPrompt: trimmed,
+      clarifyingQuestions: clarifyingQuestions.length > 0 ? clarifyingQuestions : undefined,
+      generationSpec,
+      schemaSource,
+      modelId,
     });
   };
 
@@ -99,16 +187,26 @@ function App() {
       prev.map((m) =>
         m.id === assistantId && m.role === 'assistant'
           ? { ...m, loading: false, planText: 'Updated. I applied your refinements to the schema.' }
-          : m
-      )
+          : m,
+      ),
     );
   };
 
   const handleNewProject = () => {
     setMessages([]);
     setPrompt('');
+    setGroundingFiles([]);
+    setLandingSchema(null);
+    setLandingStats(null);
+    setLandingSourceRows(0);
+    setLandingModelId(null);
     setView('landing');
   };
+
+  const profileSummary =
+    landingSchema && landingSchema.length > 0
+      ? { columns: landingSchema.length, sourceRows: landingSourceRows }
+      : null;
 
   return (
     <div className="app">
@@ -131,6 +229,11 @@ function App() {
           setProfiles={setProfiles}
           selectedId={selectedId}
           setSelectedId={setSelectedId}
+          groundingFiles={groundingFiles}
+          onGroundingFilesChange={handleGroundingFilesChange}
+          inferredSchema={landingSchema}
+          schemaInferring={schemaInferring}
+          profileSummary={profileSummary}
         />
       ) : (
         <Workspace

--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -1,0 +1,140 @@
+export interface SchemaColumn {
+  column: string;
+  type: string;
+  distribution: string;
+  sample: string;
+  null_pct?: number;
+}
+
+export type SourceStats = Record<string, Record<string, unknown>>;
+
+export interface InferSchemaResponse {
+  columns: SchemaColumn[];
+  stats: SourceStats;
+  source_rows: number;
+  model_id?: string | null;
+  error?: string;
+}
+
+export interface ValidationMetric {
+  label: string;
+  score: number;
+  status: 'pass' | 'warn' | 'fail';
+}
+
+export interface ValidationColumnResult {
+  column: string;
+  fidelity: number;
+  status: 'pass' | 'warn' | 'fail';
+  note?: string;
+}
+
+export interface ValidationReportData {
+  verdict: string;
+  verdictStatus: 'pass' | 'warn' | 'fail';
+  metrics: ValidationMetric[];
+  columns: ValidationColumnResult[];
+  insights: string[];
+}
+
+export interface GenerateResponse {
+  session_id: string;
+  row_count: number;
+  file_size_kb: number;
+  format?: string;
+  filename?: string;
+  validation: ValidationReportData;
+}
+
+export interface ClarifyingQuestion {
+  id: string;
+  question: string;
+}
+
+export interface GenerationSpec {
+  row_count: number;
+  format: 'csv' | 'jsonl' | 'parquet';
+  labels: string[];
+  edge_cases: string[];
+  constraints: string[];
+}
+
+export interface PlanResponse {
+  schema: SchemaColumn[];
+  generation_spec: GenerationSpec;
+  generation_plan: {
+    intro: string;
+    steps: Array<{ title: string; description: string }>;
+  };
+  clarifying_questions: ClarifyingQuestion[];
+}
+
+const BASE = '/api';
+
+export async function inferSchema(files: File[]): Promise<InferSchemaResponse> {
+  const form = new FormData();
+  files.forEach((f) => form.append('files', f));
+  const res = await fetch(`${BASE}/infer-schema`, { method: 'POST', body: form });
+  if (!res.ok) throw new Error(`Schema inference failed: ${res.statusText}`);
+  return res.json();
+}
+
+export async function planFromPrompt(prompt: string): Promise<PlanResponse> {
+  const res = await fetch(`${BASE}/plan`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ prompt }),
+  });
+  if (!res.ok) throw new Error(`Plan generation failed: ${res.statusText}`);
+  return res.json();
+}
+
+export async function previewDataset(
+  schemaColumns: SchemaColumn[],
+  sourceStats: SourceStats,
+  modelId?: string | null,
+): Promise<{ rows: Record<string, unknown>[] }> {
+  const res = await fetch(`${BASE}/preview`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({
+      schema_columns: schemaColumns,
+      source_stats: sourceStats,
+      row_count: 10,
+      prompt: '',
+      model_id: modelId ?? null,
+    }),
+  });
+  if (!res.ok) throw new Error(`Preview failed: ${res.statusText}`);
+  return res.json();
+}
+
+export async function generate(
+  schemaColumns: SchemaColumn[],
+  sourceStats: SourceStats,
+  rowCount: number,
+  prompt: string,
+  format: 'csv' | 'jsonl' | 'parquet' = 'csv',
+  edgeCases: string[] = [],
+  modelId?: string | null,
+): Promise<GenerateResponse> {
+  const res = await fetch(`${BASE}/generate`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({
+      schema_columns: schemaColumns,
+      source_stats: sourceStats,
+      row_count: rowCount,
+      prompt,
+      format,
+      edge_cases: edgeCases,
+      model_id: modelId ?? null,
+    }),
+  });
+  if (!res.ok) throw new Error(`Generation failed: ${res.statusText}`);
+  return res.json();
+}
+
+export function downloadUrl(sessionId: string): string {
+  return `${BASE}/download/${sessionId}`;
+}

--- a/frontend/src/components/attachment/AttachmentMenu.tsx
+++ b/frontend/src/components/attachment/AttachmentMenu.tsx
@@ -6,6 +6,12 @@ interface AttachedFile {
   id: string;
   name: string;
   size: number;
+  file: File;
+}
+
+interface AttachmentMenuProps {
+  onGroundingChange?: (files: File[]) => void;
+  profileSummary?: { columns: number; sourceRows: number } | null;
 }
 
 function formatSize(bytes: number): string {
@@ -14,7 +20,7 @@ function formatSize(bytes: number): string {
   return `${(bytes / (1024 * 1024)).toFixed(1)} MB`;
 }
 
-export default function AttachmentMenu() {
+export default function AttachmentMenu({ onGroundingChange, profileSummary }: AttachmentMenuProps) {
   const [open, setOpen] = useState(false);
   const [groundingFiles, setGroundingFiles] = useState<AttachedFile[]>([]);
   const [contextFiles, setContextFiles] = useState<AttachedFile[]>([]);
@@ -41,7 +47,14 @@ export default function AttachmentMenu() {
       id: `${f.name}-${f.size}-${Date.now()}`,
       name: f.name,
       size: f.size,
+      file: f,
     }));
+
+  const addGrounding = (list: FileList) => {
+    const next = [...groundingFiles, ...makeFiles(list)];
+    setGroundingFiles(next);
+    onGroundingChange?.(next.map((f) => f.file));
+  };
 
   const totalAttached = groundingFiles.length + contextFiles.length;
 
@@ -73,8 +86,7 @@ export default function AttachmentMenu() {
             onDrop={(e) => {
               e.preventDefault();
               setDragOverGrounding(false);
-              if (e.dataTransfer.files?.length)
-                setGroundingFiles((p) => [...p, ...makeFiles(e.dataTransfer.files)]);
+              if (e.dataTransfer.files?.length) addGrounding(e.dataTransfer.files);
             }}
           >
             <Upload size={14} />
@@ -87,8 +99,7 @@ export default function AttachmentMenu() {
             hidden
             accept=".csv,.xlsx,.xls,.parquet"
             onChange={(e) => {
-              if (e.target.files?.length)
-                setGroundingFiles((p) => [...p, ...makeFiles(e.target.files!)]);
+              if (e.target.files?.length) addGrounding(e.target.files);
               e.target.value = '';
             }}
           />
@@ -106,6 +117,17 @@ export default function AttachmentMenu() {
                   <span className="attach-size">{formatSize(f.size)}</span>
                 </div>
               ))}
+              {profileSummary && (
+                <div className="attach-profile-banner">
+                  <Check size={10} strokeWidth={2.5} />
+                  <span>
+                    Profiled · <strong>{profileSummary.columns}</strong> columns
+                    {profileSummary.sourceRows > 0 && (
+                      <> · <strong>{profileSummary.sourceRows.toLocaleString()}</strong> source rows</>
+                    )}
+                  </span>
+                </div>
+              )}
             </div>
           )}
 

--- a/frontend/src/components/landing/Landing.tsx
+++ b/frontend/src/components/landing/Landing.tsx
@@ -2,6 +2,7 @@ import type { Dispatch, SetStateAction } from 'react';
 import Logo from '../Logo';
 import PromptBox from './PromptBox';
 import type { Profile } from '../../constants/integrations';
+import type { SchemaColumn } from '../../api/client';
 
 interface LandingProps {
   prompt: string;
@@ -12,9 +13,58 @@ interface LandingProps {
   setProfiles: Dispatch<SetStateAction<Profile[]>>;
   selectedId: string;
   setSelectedId: Dispatch<SetStateAction<string>>;
+  groundingFiles?: File[];
+  onGroundingFilesChange?: (files: File[]) => void;
+  inferredSchema?: SchemaColumn[] | null;
+  schemaInferring?: boolean;
+  profileSummary?: { columns: number; sourceRows: number } | null;
+}
+
+const VALIDATION_LABELS = ['Realism', 'Diversity', 'Safety / PII'];
+
+const PLACEHOLDER_ROWS = [null, null, null] as const;
+
+function buildSteps(fileNames: string[]) {
+  const fileRef =
+    fileNames.length === 0
+      ? 'your connected sources'
+      : fileNames.length === 1
+        ? fileNames[0]
+        : `${fileNames.slice(0, 2).join(', ')}${fileNames.length > 2 ? ` +${fileNames.length - 2} more` : ''}`;
+
+  return [
+    {
+      num: '01',
+      title: 'Schema inference',
+      desc: `Scans ${fileRef} to extract column signatures, infer types, and model statistical distributions.`,
+    },
+    {
+      num: '02',
+      title: 'Sample synthesis',
+      desc: 'Generates statistically faithful rows that preserve inter-column correlations and your profile constraints.',
+    },
+    {
+      num: '03',
+      title: 'Fidelity validation',
+      desc: 'Cross-validates synthesized distributions against source samples and issues a quality report before delivery.',
+    },
+  ];
 }
 
 export default function Landing(props: LandingProps) {
+  const {
+    groundingFiles = [],
+    onGroundingFilesChange,
+    inferredSchema,
+    schemaInferring,
+    profileSummary,
+    ...promptProps
+  } = props;
+
+  const steps = buildSteps(groundingFiles.map((f) => f.name));
+  const schemaRows = inferredSchema ? inferredSchema.slice(0, 4) : null;
+  const extraCols = inferredSchema && inferredSchema.length > 4 ? inferredSchema.length - 4 : 0;
+
   return (
     <div className="landing">
       <h1 className="landing-title">
@@ -22,7 +72,69 @@ export default function Landing(props: LandingProps) {
         What should we synthesize?
       </h1>
 
-      <PromptBox {...props} />
+      <PromptBox
+        {...promptProps}
+        onGroundingFilesChange={onGroundingFilesChange}
+        profileSummary={profileSummary}
+      />
+
+      <div className="landing-steps">
+        {steps.map((s) => (
+          <div key={s.num} className="landing-step">
+            <span className="landing-step-num">{s.num}</span>
+            <span className="landing-step-title">{s.title}</span>
+            <p className="landing-step-desc">{s.desc}</p>
+          </div>
+        ))}
+      </div>
+
+      <div className="landing-output">
+        <div className="landing-output-col">
+          <span className="landing-output-label">
+            Schema
+            {schemaInferring && <span className="landing-output-inferring">inferring…</span>}
+          </span>
+          <div className="landing-schema">
+            <div className="landing-schema-header">
+              <span>Column</span>
+              <span>Type</span>
+              <span>Sample</span>
+            </div>
+            {schemaRows
+              ? schemaRows.map((row) => (
+                  <div key={row.column} className="landing-schema-row">
+                    <span className="landing-schema-name">{row.column}</span>
+                    <span className="landing-schema-type">{row.type}</span>
+                    <span className="landing-schema-sample">{row.sample || '—'}</span>
+                  </div>
+                ))
+              : PLACEHOLDER_ROWS.map((_, i) => (
+                  <div key={i} className="landing-schema-row landing-schema-row-empty">
+                    <span className="landing-schema-name">—</span>
+                    <span className="landing-schema-type">—</span>
+                    <span className="landing-schema-sample">—</span>
+                  </div>
+                ))}
+            {extraCols > 0 && (
+              <div className="landing-schema-extra">+{extraCols} more column{extraCols > 1 ? 's' : ''}</div>
+            )}
+          </div>
+        </div>
+
+        <div className="landing-output-col">
+          <span className="landing-output-label">Validation report</span>
+          <div className="landing-vp-metrics">
+            {VALIDATION_LABELS.map((label) => (
+              <div key={label} className="landing-vp-row">
+                <span className="landing-vp-row-label">{label}</span>
+                <div className="landing-vp-track" />
+                <span className="landing-vp-score landing-vp-score-empty">—</span>
+              </div>
+            ))}
+          </div>
+          <span className="landing-vp-hint">Scores appear after generation</span>
+        </div>
+      </div>
     </div>
   );
 }

--- a/frontend/src/components/landing/PromptBox.tsx
+++ b/frontend/src/components/landing/PromptBox.tsx
@@ -13,6 +13,8 @@ interface PromptBoxProps {
   setProfiles: Dispatch<SetStateAction<Profile[]>>;
   selectedId: string;
   setSelectedId: Dispatch<SetStateAction<string>>;
+  onGroundingFilesChange?: (files: File[]) => void;
+  profileSummary?: { columns: number; sourceRows: number } | null;
 }
 
 export default function PromptBox({
@@ -24,6 +26,8 @@ export default function PromptBox({
   setProfiles,
   selectedId,
   setSelectedId,
+  onGroundingFilesChange,
+  profileSummary,
 }: PromptBoxProps) {
   const handleKeyDown = (e: ReactKeyboardEvent<HTMLTextAreaElement>) => {
     if (e.key === 'Enter' && !e.shiftKey) {
@@ -43,7 +47,10 @@ export default function PromptBox({
       />
       <div className="prompt-box-footer">
         <div className="prompt-meta">
-          <AttachmentMenu />
+          <AttachmentMenu
+            onGroundingChange={onGroundingFilesChange}
+            profileSummary={profileSummary}
+          />
           <ProfileSelector
             profiles={profiles}
             setProfiles={setProfiles}

--- a/frontend/src/components/workspace/AssistantMessage.tsx
+++ b/frontend/src/components/workspace/AssistantMessage.tsx
@@ -3,25 +3,101 @@ import Logo from '../Logo';
 import AgentTaskList from './AgentTaskList';
 import SchemaCard from './SchemaCard';
 import ValidationReport from './ValidationReport';
+import ClarifyingQuestions from './ClarifyingQuestions';
+import PreviewTable from './PreviewTable';
 import { Download } from '../icons/Icons';
-import type { WorkspaceMessage } from '../../constants/mockWorkspace';
+import type { WorkspaceMessage, ApprovalState } from '../../constants/mockWorkspace';
 import { VALIDATION_REPORT } from '../../constants/mockWorkspace';
+import {
+  generate,
+  previewDataset,
+  downloadUrl,
+  type GenerateResponse,
+  type SourceStats,
+} from '../../api/client';
 
 type Props = Extract<WorkspaceMessage, { role: 'assistant' }>;
-type ApprovalState = 'idle' | 'generating' | 'validating' | 'complete';
 
-const wait = (ms: number) => new Promise<void>((r) => window.setTimeout(r, ms));
+const FORMAT_OPTIONS = ['csv', 'jsonl', 'parquet'] as const;
+type Format = (typeof FORMAT_OPTIONS)[number];
 
-export default function AssistantMessage({ loading, plan, planText, agents, schema }: Props) {
-  const [approval, setApproval] = useState<ApprovalState>('idle');
+export default function AssistantMessage({
+  loading,
+  plan,
+  planText,
+  agents,
+  schema,
+  sourceStats,
+  originalPrompt,
+  initialApproval,
+  clarifyingQuestions,
+  generationSpec,
+  schemaSource,
+  modelId,
+}: Props) {
+  const [approval, setApproval] = useState<ApprovalState>(initialApproval ?? 'idle');
+  const [genResult, setGenResult] = useState<GenerateResponse | null>(null);
+  const [genError, setGenError] = useState<string | null>(null);
+
+  const [rowCount, setRowCount] = useState(generationSpec?.row_count ?? 10_000);
+  const [format, setFormat] = useState<Format>(generationSpec?.format ?? 'csv');
+
+  const [previewRows, setPreviewRows] = useState<Record<string, unknown>[] | null>(null);
+  const [previewLoading, setPreviewLoading] = useState(false);
+
+  const [clarifyDismissed, setClarifyDismissed] = useState(false);
+
+  const hasClarifying = (clarifyingQuestions?.length ?? 0) > 0 && !clarifyDismissed;
+
+  const handlePreview = async () => {
+    if (!schema || schema.length === 0) return;
+    setPreviewLoading(true);
+    try {
+      const result = await previewDataset(
+        schema,
+        (sourceStats as SourceStats) ?? {},
+        modelId,
+      );
+      setPreviewRows(result.rows);
+    } catch {
+      // non-fatal
+    } finally {
+      setPreviewLoading(false);
+    }
+  };
 
   const handleApprove = async () => {
     setApproval('generating');
-    await wait(2200);
-    setApproval('validating');
-    await wait(1600);
-    setApproval('complete');
+    setGenError(null);
+
+    try {
+      const result = await generate(
+        schema ?? [],
+        (sourceStats as SourceStats) ?? {},
+        rowCount,
+        originalPrompt ?? '',
+        format,
+        generationSpec?.edge_cases ?? [],
+        modelId,
+      );
+      setApproval('validating');
+      await new Promise<void>((r) => window.setTimeout(r, 800));
+      setGenResult(result);
+      setApproval('complete');
+    } catch (err) {
+      setGenError(err instanceof Error ? err.message : 'Generation failed');
+      setApproval('idle');
+    }
   };
+
+  const report = genResult?.validation ?? VALIDATION_REPORT;
+  const rowCountActual = genResult?.row_count ?? rowCount;
+  const fileSizeKb = genResult?.file_size_kb ?? 0;
+  const fileSizeFmt =
+    fileSizeKb >= 1024
+      ? `${(fileSizeKb / 1024).toFixed(1)} MB`
+      : `${fileSizeKb} KB`;
+  const filename = genResult?.filename ?? `aperture_output.${format}`;
 
   return (
     <div className="ws-msg ws-msg-assistant">
@@ -55,42 +131,120 @@ export default function AssistantMessage({ loading, plan, planText, agents, sche
             )}
             {planText && <p className="ws-msg-text">{planText}</p>}
             {agents && <AgentTaskList agents={agents} />}
-            {schema && <SchemaCard rows={schema} />}
             {schema && (
-              <div className="ws-approve-row">
-                {approval === 'idle' && (
-                  <button className="ws-approve-btn" onClick={handleApprove}>
-                    Approve & run
-                  </button>
+              <>
+                <SchemaCard rows={schema} source={schemaSource} />
+
+                {hasClarifying && clarifyingQuestions && (
+                  <ClarifyingQuestions
+                    questions={clarifyingQuestions}
+                    onDismiss={() => setClarifyDismissed(true)}
+                  />
                 )}
-                {approval === 'generating' && (
-                  <div className="ws-generating">
-                    <span className="spinner" />
-                    Generating dataset…
-                  </div>
-                )}
-                {approval === 'validating' && (
-                  <div className="ws-generating">
-                    <span className="spinner" />
-                    Running validation checks…
-                  </div>
-                )}
-                {approval === 'complete' && (
-                  <>
-                    <div className="ws-download-card">
-                      <div className="ws-download-info">
-                        <span className="ws-download-filename">diabetic_cohort.csv</span>
-                        <span className="ws-download-meta">10,000 rows · CSV · 2.4 MB</span>
+
+                <div className="ws-approve-row">
+                  {approval === 'idle' && (
+                    <>
+                      {/* Generation controls */}
+                      <div className="ws-gen-controls">
+                        <div className="ws-gen-control-group">
+                          <label className="ws-gen-control-label">Rows</label>
+                          <input
+                            className="ws-rowcount-input"
+                            type="number"
+                            min={100}
+                            max={100_000}
+                            step={1_000}
+                            value={rowCount}
+                            onChange={(e) =>
+                              setRowCount(
+                                Math.max(100, Math.min(100_000, Number(e.target.value) || 100)),
+                              )
+                            }
+                          />
+                        </div>
+                        <div className="ws-gen-control-group">
+                          <label className="ws-gen-control-label">Format</label>
+                          <div className="ws-format-opts">
+                            {FORMAT_OPTIONS.map((f) => (
+                              <button
+                                key={f}
+                                className={`ws-format-opt${format === f ? ' ws-format-opt-active' : ''}`}
+                                onClick={() => setFormat(f)}
+                              >
+                                {f.toUpperCase()}
+                              </button>
+                            ))}
+                          </div>
+                        </div>
+                        <span className={`ws-synth-badge${modelId ? ' ws-synth-badge-sdv' : ''}`}>
+                          {modelId ? 'SDV · correlation-preserving' : 'Statistical sampler'}
+                        </span>
+                        <button
+                          className="ws-preview-btn"
+                          onClick={handlePreview}
+                          disabled={previewLoading}
+                        >
+                          {previewLoading ? <span className="spinner ws-spinner-sm" /> : null}
+                          Preview 10 rows
+                        </button>
                       </div>
-                      <button className="ws-download-btn">
-                        <Download size={13} />
-                        Download
-                      </button>
+
+                      {previewRows && <PreviewTable rows={previewRows} />}
+
+                      <div className="ws-approve-action-row">
+                        <button className="ws-approve-btn" onClick={handleApprove}>
+                          Approve &amp; generate
+                        </button>
+                        {genError && (
+                          <span className="ws-gen-error">{genError}</span>
+                        )}
+                      </div>
+                    </>
+                  )}
+
+                  {approval === 'generating' && (
+                    <div className="ws-generating">
+                      <span className="spinner" />
+                      Generating {rowCount.toLocaleString()} rows…
                     </div>
-                    <ValidationReport report={VALIDATION_REPORT} />
-                  </>
-                )}
-              </div>
+                  )}
+                  {approval === 'validating' && (
+                    <div className="ws-generating">
+                      <span className="spinner" />
+                      Running validation checks…
+                    </div>
+                  )}
+                  {approval === 'complete' && (
+                    <>
+                      <div className="ws-download-card">
+                        <div className="ws-download-info">
+                          <span className="ws-download-filename">{filename}</span>
+                          <span className="ws-download-meta">
+                            {rowCountActual.toLocaleString()} rows · {format.toUpperCase()} · {fileSizeFmt}
+                          </span>
+                        </div>
+                        {genResult ? (
+                          <a
+                            className="ws-download-btn"
+                            href={downloadUrl(genResult.session_id)}
+                            download
+                          >
+                            <Download size={13} />
+                            Download
+                          </a>
+                        ) : (
+                          <button className="ws-download-btn" disabled>
+                            <Download size={13} />
+                            Download
+                          </button>
+                        )}
+                      </div>
+                      <ValidationReport report={report} />
+                    </>
+                  )}
+                </div>
+              </>
             )}
           </>
         )}

--- a/frontend/src/components/workspace/ClarifyingQuestions.tsx
+++ b/frontend/src/components/workspace/ClarifyingQuestions.tsx
@@ -1,0 +1,53 @@
+import { useState } from 'react';
+import type { ClarifyingQuestion } from '../../constants/mockWorkspace';
+
+interface Props {
+  questions: ClarifyingQuestion[];
+  onDismiss: (answers: Record<string, string>) => void;
+}
+
+export default function ClarifyingQuestions({ questions, onDismiss }: Props) {
+  const [answers, setAnswers] = useState<Record<string, string>>({});
+
+  const allAnswered = questions.every((q) => (answers[q.id] ?? '').trim().length > 0);
+
+  return (
+    <div className="ws-clarify-card">
+      <div className="ws-clarify-header">
+        <span className="ws-clarify-title">A few questions to refine your dataset</span>
+        <span className="ws-clarify-hint">Optional — skip to use the inferred schema as-is</span>
+      </div>
+      <div className="ws-clarify-body">
+        {questions.map((q, i) => (
+          <div key={q.id} className="ws-clarify-row">
+            <label className="ws-clarify-label">
+              <span className="ws-clarify-num">{i + 1}</span>
+              {q.question}
+            </label>
+            <input
+              className="ws-clarify-input"
+              type="text"
+              placeholder="Your answer…"
+              value={answers[q.id] ?? ''}
+              onChange={(e) =>
+                setAnswers((prev) => ({ ...prev, [q.id]: e.target.value }))
+              }
+            />
+          </div>
+        ))}
+      </div>
+      <div className="ws-clarify-footer">
+        <button
+          className="ws-approve-btn"
+          disabled={!allAnswered}
+          onClick={() => onDismiss(answers)}
+        >
+          Refine schema
+        </button>
+        <button className="ws-clarify-skip" onClick={() => onDismiss({})}>
+          Skip, use defaults
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/components/workspace/PreviewTable.tsx
+++ b/frontend/src/components/workspace/PreviewTable.tsx
@@ -1,0 +1,43 @@
+interface Props {
+  rows: Record<string, unknown>[];
+}
+
+export default function PreviewTable({ rows }: Props) {
+  if (rows.length === 0) return null;
+
+  const columns = Object.keys(rows[0]);
+
+  return (
+    <div className="ws-preview-card">
+      <div className="ws-preview-header">
+        <span className="ws-preview-title">Sample preview · {rows.length} rows</span>
+        <span className="ws-preview-badge">Synthetic</span>
+      </div>
+      <div className="ws-preview-scroll">
+        <table className="ws-preview-table">
+          <thead>
+            <tr>
+              {columns.map((col) => (
+                <th key={col}>{col}</th>
+              ))}
+            </tr>
+          </thead>
+          <tbody>
+            {rows.map((row, i) => (
+              <tr key={i}>
+                {columns.map((col) => {
+                  const val = String(row[col] ?? '');
+                  return (
+                    <td key={col} title={val}>
+                      {val.length > 18 ? val.slice(0, 16) + '…' : val}
+                    </td>
+                  );
+                })}
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/components/workspace/SchemaCard.tsx
+++ b/frontend/src/components/workspace/SchemaCard.tsx
@@ -2,13 +2,16 @@ import type { SchemaRow } from '../../constants/mockWorkspace';
 
 interface SchemaCardProps {
   rows: SchemaRow[];
+  source?: 'llm' | 'upload';
 }
 
-export default function SchemaCard({ rows }: SchemaCardProps) {
+export default function SchemaCard({ rows, source }: SchemaCardProps) {
+  const sourceLabel = source === 'llm' ? 'AI-inferred' : source === 'upload' ? 'File-grounded' : null;
   return (
     <div className="ws-schema-card">
       <div className="ws-schema-header">
         <span className="ws-schema-title">Inferred schema · {rows.length} columns</span>
+        {sourceLabel && <span className="ws-schema-source-badge">{sourceLabel}</span>}
       </div>
       <div className="ws-schema-table">
         <div className="ws-schema-row ws-schema-row-head">

--- a/frontend/src/components/workspace/ValidationReport.tsx
+++ b/frontend/src/components/workspace/ValidationReport.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 import { Check, ChevronDown } from '../icons/Icons';
 import type { ValidationReport as ValidationReportType } from '../../constants/mockWorkspace';
 
@@ -19,6 +19,12 @@ function WarnIcon() {
 
 export default function ValidationReport({ report }: Props) {
   const [colsExpanded, setColsExpanded] = useState(true);
+  const [animated, setAnimated] = useState(false);
+
+  useEffect(() => {
+    const t = window.setTimeout(() => setAnimated(true), 60);
+    return () => window.clearTimeout(t);
+  }, []);
 
   return (
     <div className="ws-validation-card">
@@ -41,7 +47,7 @@ export default function ValidationReport({ report }: Props) {
           <div className="ws-coverage-bar-track">
             <div
               className="ws-coverage-bar"
-              style={{ width: `${report.edgeCaseCoverage.coveragePct}%` }}
+              style={{ width: animated ? `${report.edgeCaseCoverage.coveragePct}%` : '0%' }}
             />
           </div>
           <div className="ws-coverage-count">
@@ -58,7 +64,7 @@ export default function ValidationReport({ report }: Props) {
             <div className="ws-validation-bar-track">
               <div
                 className={`ws-validation-bar ws-validation-bar-${m.status}`}
-                style={{ width: `${m.score}%` }}
+                style={{ width: animated ? `${m.score}%` : '0%' }}
               />
             </div>
             <div className="ws-validation-metric-footer">
@@ -92,7 +98,7 @@ export default function ValidationReport({ report }: Props) {
               <div className="ws-validation-mini-track">
                 <div
                   className={`ws-validation-mini-bar ws-validation-bar-${col.status}`}
-                  style={{ width: `${col.fidelity}%` }}
+                  style={{ width: animated ? `${col.fidelity}%` : '0%' }}
                 />
               </div>
               <span className={`ws-validation-col-pct ws-validation-score-${col.status}`}>

--- a/frontend/src/constants/mockWorkspace.ts
+++ b/frontend/src/constants/mockWorkspace.ts
@@ -84,6 +84,22 @@ export interface ExecutionPlan {
   steps: PlanStep[];
 }
 
+export type ApprovalState = 'idle' | 'generating' | 'validating' | 'complete';
+
+export interface ClarifyingQuestion {
+  id: string;
+  question: string;
+  answer?: string;
+}
+
+export interface GenerationSpec {
+  row_count: number;
+  format: 'csv' | 'jsonl' | 'parquet';
+  labels: string[];
+  edge_cases: string[];
+  constraints: string[];
+}
+
 export type WorkspaceMessage =
   | { id: string; role: 'user'; text: string }
   | {
@@ -94,6 +110,13 @@ export type WorkspaceMessage =
       planText?: string;
       agents?: AgentTask[];
       schema?: SchemaRow[];
+      initialApproval?: ApprovalState;
+      sourceStats?: Record<string, Record<string, unknown>>;
+      originalPrompt?: string;
+      clarifyingQuestions?: ClarifyingQuestion[];
+      generationSpec?: GenerationSpec;
+      schemaSource?: 'llm' | 'upload';
+      modelId?: string | null;
     };
 
 export const SCHEMA_TAG = 'APERTURE V1 · CLINICAL';
@@ -158,3 +181,22 @@ export function buildAgents(sourceNames: string[]): AgentTask[] {
     },
   ];
 }
+
+const DEMO_SOURCES = ['Amazon S3', 'PostgreSQL', 'MongoDB'];
+
+export const DEMO_MESSAGES: WorkspaceMessage[] = [
+  {
+    id: 'demo-user-1',
+    role: 'user',
+    text: 'Generate 10,000 diabetic cohort records grounded in our clinical EHR data — include edge cases for HbA1c > 12 with 3+ comorbidities',
+  },
+  {
+    id: 'demo-assistant-1',
+    role: 'assistant',
+    loading: false,
+    plan: buildExecutionPlan(DEMO_SOURCES),
+    agents: buildAgents(DEMO_SOURCES).map((a) => ({ ...a, status: 'done' as AgentStatus })),
+    schema: SCHEMA_ROWS,
+    initialApproval: 'complete',
+  },
+];

--- a/frontend/src/styles/attachment.css
+++ b/frontend/src/styles/attachment.css
@@ -153,6 +153,22 @@
   color: var(--text-dim);
 }
 
+.attach-profile-banner {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  padding: 6px 10px;
+  background: rgba(122, 154, 109, 0.1);
+  border-radius: 6px;
+  font-size: 12px;
+  color: var(--accent);
+  margin-top: 4px;
+}
+
+.attach-profile-banner strong {
+  font-weight: 600;
+}
+
 @media (max-width: 480px) {
   .attach-menu {
     width: 280px;

--- a/frontend/src/styles/landing.css
+++ b/frontend/src/styles/landing.css
@@ -99,9 +99,218 @@
   opacity: 0.9;
 }
 
+/* Pipeline steps */
+.landing-steps {
+  width: 100%;
+  margin-top: 36px;
+  display: grid;
+  grid-template-columns: 1fr 1fr 1fr;
+  gap: 2px;
+  border: 1px solid var(--border);
+  border-radius: 12px;
+  overflow: hidden;
+}
+
+.landing-step {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  padding: 18px 20px;
+  background: var(--surface);
+}
+
+.landing-step + .landing-step {
+  border-left: 1px solid var(--border);
+}
+
+.landing-step-num {
+  font-size: 10px;
+  font-family: ui-monospace, "Cascadia Code", monospace;
+  color: var(--accent);
+  letter-spacing: 0.08em;
+}
+
+.landing-step-title {
+  font-size: 13px;
+  color: var(--text);
+  font-weight: 500;
+}
+
+.landing-step-desc {
+  font-size: 12px;
+  color: var(--text-dim);
+  line-height: 1.55;
+  margin: 0;
+}
+
+/* Output preview */
+.landing-output {
+  width: 100%;
+  margin-top: 10px;
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 2px;
+  border: 1px solid var(--border);
+  border-radius: 12px;
+  overflow: hidden;
+}
+
+.landing-output-col {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+  padding: 18px 20px;
+  background: var(--surface);
+}
+
+.landing-output-col + .landing-output-col {
+  border-left: 1px solid var(--border);
+}
+
+.landing-output-label {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  font-size: 10px;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  color: var(--text-dim);
+}
+
+.landing-output-inferring {
+  font-size: 10px;
+  color: var(--accent);
+  text-transform: none;
+  letter-spacing: 0;
+  animation: pulse 1.2s ease-in-out infinite;
+}
+
+@keyframes pulse {
+  0%, 100% { opacity: 1; }
+  50% { opacity: 0.4; }
+}
+
+/* Schema mini-table */
+.landing-schema {
+  display: flex;
+  flex-direction: column;
+  gap: 5px;
+}
+
+.landing-schema-header,
+.landing-schema-row {
+  display: grid;
+  grid-template-columns: 1fr 52px 52px;
+  gap: 8px;
+}
+
+.landing-schema-header {
+  font-size: 10px;
+  color: var(--text-dim);
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+  padding-bottom: 4px;
+  border-bottom: 1px solid var(--border);
+}
+
+.landing-schema-row {
+  font-size: 12px;
+}
+
+.landing-schema-name {
+  color: var(--text-muted);
+  font-family: ui-monospace, "Cascadia Code", monospace;
+  font-size: 11px;
+}
+
+.landing-schema-type {
+  color: var(--text-dim);
+  font-family: ui-monospace, "Cascadia Code", monospace;
+  font-size: 11px;
+}
+
+.landing-schema-sample {
+  color: var(--text-dim);
+  font-size: 11px;
+}
+
+.landing-schema-row-empty .landing-schema-name,
+.landing-schema-row-empty .landing-schema-type,
+.landing-schema-row-empty .landing-schema-sample {
+  color: var(--border);
+}
+
+.landing-schema-extra {
+  font-size: 10px;
+  color: var(--text-dim);
+  padding-top: 4px;
+}
+
+/* Validation metrics (shared, used in output preview) */
+.landing-vp-metrics {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.landing-vp-row {
+  display: grid;
+  grid-template-columns: 78px 1fr 26px;
+  align-items: center;
+  gap: 10px;
+}
+
+.landing-vp-row-label {
+  font-size: 12px;
+  color: var(--text-muted);
+}
+
+.landing-vp-track {
+  height: 3px;
+  background: var(--border);
+  border-radius: 2px;
+  overflow: hidden;
+}
+
+.landing-vp-fill {
+  height: 100%;
+  background: var(--accent);
+  border-radius: 2px;
+}
+
+.landing-vp-score {
+  font-size: 11px;
+  color: var(--text-dim);
+  text-align: right;
+}
+
+.landing-vp-score-empty {
+  color: var(--border);
+}
+
+.landing-vp-hint {
+  font-size: 10px;
+  color: var(--text-dim);
+  margin-top: 6px;
+}
+
 @media (max-width: 720px) {
   .landing-title { font-size: 28px; }
   .landing { padding: 0 16px 60px; }
+  .landing-steps {
+    grid-template-columns: 1fr;
+  }
+  .landing-step + .landing-step {
+    border-left: none;
+    border-top: 1px solid var(--border);
+  }
+  .landing-output {
+    grid-template-columns: 1fr;
+  }
+  .landing-output-col + .landing-output-col {
+    border-left: none;
+    border-top: 1px solid var(--border);
+  }
 }
 
 @media (max-width: 480px) {

--- a/frontend/src/styles/workspace.css
+++ b/frontend/src/styles/workspace.css
@@ -537,6 +537,18 @@
   opacity: 0.88;
 }
 
+.ws-download-btn[disabled] {
+  opacity: 0.4;
+  cursor: not-allowed;
+}
+
+.ws-gen-error {
+  font-size: 12px;
+  color: #e07070;
+  margin-top: 6px;
+  display: block;
+}
+
 /* Validation report card */
 .ws-validation-card {
   background: var(--surface);
@@ -768,6 +780,7 @@
 .ws-validation-mini-bar {
   height: 100%;
   border-radius: 2px;
+  transition: width 0.6s ease;
 }
 
 .ws-validation-col-pct {
@@ -826,6 +839,316 @@
   background: var(--text-dim);
   flex-shrink: 0;
   margin-top: 6px;
+}
+
+/* Schema source badge */
+.ws-schema-source-badge {
+  font-size: 10px;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: var(--accent);
+  background: var(--accent-soft);
+  padding: 2px 8px;
+  border-radius: 10px;
+}
+
+/* Clarifying questions card */
+.ws-clarify-card {
+  background: var(--surface);
+  border: 1px solid var(--border);
+  border-radius: 14px;
+  overflow: hidden;
+  margin: 12px 0;
+}
+
+.ws-clarify-header {
+  display: flex;
+  align-items: baseline;
+  justify-content: space-between;
+  padding: 14px 18px;
+  border-bottom: 1px solid var(--border);
+  gap: 12px;
+}
+
+.ws-clarify-title {
+  font-size: 13px;
+  font-weight: 500;
+  color: var(--text);
+}
+
+.ws-clarify-hint {
+  font-size: 11px;
+  color: var(--text-dim);
+  white-space: nowrap;
+}
+
+.ws-clarify-body {
+  display: flex;
+  flex-direction: column;
+  gap: 0;
+}
+
+.ws-clarify-row {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  padding: 14px 18px;
+  border-bottom: 1px solid var(--border);
+}
+
+.ws-clarify-row:last-child {
+  border-bottom: none;
+}
+
+.ws-clarify-label {
+  display: flex;
+  align-items: flex-start;
+  gap: 8px;
+  font-size: 13px;
+  color: var(--text-muted);
+  line-height: 1.4;
+}
+
+.ws-clarify-num {
+  width: 18px;
+  height: 18px;
+  flex-shrink: 0;
+  border-radius: 50%;
+  border: 1px solid var(--border);
+  background: var(--bg);
+  font-family: var(--mono);
+  font-size: 10px;
+  color: var(--text-dim);
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  margin-top: 1px;
+}
+
+.ws-clarify-input {
+  width: 100%;
+  padding: 8px 12px;
+  background: var(--bg);
+  border: 1px solid var(--border);
+  border-radius: 8px;
+  color: var(--text);
+  font-size: 13px;
+  outline: none;
+}
+
+.ws-clarify-input:focus {
+  border-color: var(--text-dim);
+}
+
+.ws-clarify-footer {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  padding: 14px 18px;
+  border-top: 1px solid var(--border);
+}
+
+.ws-clarify-skip {
+  font-size: 12px;
+  color: var(--text-dim);
+  padding: 4px 0;
+}
+
+.ws-clarify-skip:hover {
+  color: var(--text-muted);
+}
+
+/* Generation controls row */
+.ws-gen-controls {
+  display: flex;
+  align-items: center;
+  gap: 16px;
+  flex-wrap: wrap;
+  margin-bottom: 12px;
+}
+
+.ws-gen-control-group {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+
+.ws-gen-control-label {
+  font-size: 12px;
+  color: var(--text-dim);
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+  white-space: nowrap;
+}
+
+.ws-rowcount-input {
+  width: 90px;
+  padding: 5px 10px;
+  background: var(--surface);
+  border: 1px solid var(--border);
+  border-radius: 7px;
+  color: var(--text);
+  font-size: 13px;
+  font-family: var(--mono);
+  outline: none;
+}
+
+.ws-rowcount-input:focus {
+  border-color: var(--text-dim);
+}
+
+.ws-format-opts {
+  display: flex;
+  gap: 4px;
+}
+
+.ws-format-opt {
+  padding: 4px 10px;
+  border: 1px solid var(--border);
+  border-radius: 6px;
+  font-size: 11px;
+  font-family: var(--mono);
+  letter-spacing: 0.04em;
+  color: var(--text-dim);
+  background: var(--surface);
+}
+
+.ws-format-opt:hover {
+  border-color: var(--text-dim);
+  color: var(--text-muted);
+}
+
+.ws-format-opt-active {
+  border-color: var(--accent);
+  color: var(--accent);
+  background: var(--accent-soft);
+}
+
+.ws-synth-badge {
+  font-size: 11px;
+  color: var(--text-dim);
+  border: 1px solid var(--border);
+  border-radius: 6px;
+  padding: 3px 9px;
+  white-space: nowrap;
+}
+
+.ws-synth-badge-sdv {
+  color: var(--accent);
+  border-color: var(--accent);
+  background: var(--accent-soft);
+}
+
+.ws-preview-btn {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  padding: 5px 12px;
+  border: 1px solid var(--border);
+  border-radius: 7px;
+  font-size: 12px;
+  color: var(--text-muted);
+  background: var(--surface);
+}
+
+.ws-preview-btn:hover:not(:disabled) {
+  border-color: var(--text-dim);
+}
+
+.ws-preview-btn:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+
+.ws-spinner-sm {
+  width: 10px !important;
+  height: 10px !important;
+}
+
+.ws-approve-action-row {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  margin-top: 4px;
+}
+
+/* Preview table */
+.ws-preview-card {
+  background: var(--surface);
+  border: 1px solid var(--border);
+  border-radius: 12px;
+  overflow: hidden;
+  margin-bottom: 12px;
+}
+
+.ws-preview-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 10px 16px;
+  border-bottom: 1px solid var(--border);
+}
+
+.ws-preview-title {
+  font-size: 12px;
+  color: var(--text-muted);
+  font-weight: 500;
+}
+
+.ws-preview-badge {
+  font-size: 10px;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: var(--accent);
+  background: var(--accent-soft);
+  padding: 2px 7px;
+  border-radius: 10px;
+}
+
+.ws-preview-scroll {
+  overflow-x: auto;
+  max-height: 220px;
+  overflow-y: auto;
+}
+
+.ws-preview-table {
+  width: 100%;
+  border-collapse: collapse;
+  font-size: 11px;
+}
+
+.ws-preview-table th {
+  padding: 7px 12px;
+  text-align: left;
+  font-family: var(--mono);
+  font-size: 10px;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+  color: var(--text-dim);
+  background: var(--bg);
+  border-bottom: 1px solid var(--border);
+  white-space: nowrap;
+  position: sticky;
+  top: 0;
+}
+
+.ws-preview-table td {
+  padding: 6px 12px;
+  font-family: var(--mono);
+  color: var(--text-muted);
+  border-bottom: 1px solid var(--border);
+  white-space: nowrap;
+  max-width: 140px;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.ws-preview-table tr:last-child td {
+  border-bottom: none;
+}
+
+.ws-preview-table tr:hover td {
+  background: rgba(255,255,255,0.02);
 }
 
 /* Follow-up input */

--- a/frontend/vite.config.js
+++ b/frontend/vite.config.js
@@ -1,7 +1,14 @@
 import { defineConfig } from 'vite'
 import react from '@vitejs/plugin-react'
 
-// https://vite.dev/config/
 export default defineConfig({
   plugins: [react()],
+  server: {
+    proxy: {
+      '/api': {
+        target: 'http://localhost:8000',
+        changeOrigin: true,
+      },
+    },
+  },
 })


### PR DESCRIPTION
…ols, and landing page design improvements
Prompt-to-Action Agent
- Add POST /api/plan endpoint that uses Claude (claude-sonnet-4-6) to infer
  schema, generation plan, and clarifying questions from a natural language
  prompt; falls back to domain keyword matching when no API key is set
- Wire /api/plan into App.tsx submission flow when no grounding files are
  present so the workspace plan and schema reflect the actual LLM response
- Add ClarifyingQuestions component shown when the agent determines the
  prompt is underspecified; users can answer or skip to use the inferred schema

SDV Synthesis Backend
- Integrate sdv GaussianCopulaSynthesizer: fitted during /api/infer-schema on
  uploaded data (capped at 50K rows), stored server-side by model_id
- Add _synthesize() that routes to SDV when a model_id is present and falls
  back to per-column statistical sampling otherwise; preserves inter-column
  correlations lost by the previous independent-column approach
- Thread model_id from infer-schema response through App state,
  WorkspaceMessage, and AssistantMessage into generate/preview calls
- Show "SDV · correlation-preserving" badge in generation controls when active

Dataset Generation Controls
- Add row count input (100–100,000) and CSV/JSONL/Parquet format selector
  before generation; selection forwarded to /api/generate and /api/download
- Add POST /api/preview returning 10 synthetic rows as JSON without creating
  a session; surface as "Preview 10 rows" button with PreviewTable component
- Update /api/generate to serialize output in the requested format and return
  filename; update /api/download to serve correct Content-Type per format

Internal Data Connector (MVP)
- Add null_pct (missingness %) to each column in /api/infer-schema response
- Show data profile banner in AttachmentMenu after grounding files are profiled
- Add "AI-inferred" / "File-grounded" source badge to SchemaCard

Infra
- Add anthropic and sdv to requirements.txt
- Add .gitignore covering .env, __pycache__, node_modules, dist
- Fill in backend README with endpoint docs, synthesis design, and limitations