### PR TITLE
Enforce edge cases in SDG

### DIFF
--- a/backend/api/generate.py
+++ b/backend/api/generate.py
@@ -8,6 +8,7 @@ from fastapi.responses import StreamingResponse
 
 from core.state import sessions
 from models.schemas import GenerateRequest
+from services.edge_cases import apply_edge_cases, parse_edge_cases
 from services.synthesis import synthesize
 from services.validation import validate
 
@@ -18,6 +19,8 @@ router = APIRouter(prefix="/api")
 async def preview_dataset(req: GenerateRequest):
     """Generate 10 preview rows as a JSON array — no session stored."""
     synth_df = synthesize(req.schema_columns, req.source_stats, n=10, model_id=req.model_id)
+    rules = parse_edge_cases(req.edge_cases, req.schema_columns)
+    synth_df, _ = apply_edge_cases(synth_df, rules, req.source_stats)
     return {"rows": synth_df.to_dict(orient="records")}
 
 
@@ -26,6 +29,9 @@ async def generate(req: GenerateRequest):
     """Synthesise rows, run fidelity validation, and stash the file for download."""
     n = max(1, min(req.row_count, 100_000))
     synth_df = synthesize(req.schema_columns, req.source_stats, n, model_id=req.model_id)
+
+    rules = parse_edge_cases(req.edge_cases, req.schema_columns)
+    synth_df, edge_case_report = apply_edge_cases(synth_df, rules, req.source_stats)
 
     fmt = (req.format or "csv").lower()
     if fmt not in ("csv", "jsonl", "parquet"):
@@ -45,6 +51,25 @@ async def generate(req: GenerateRequest):
     sessions[session_id] = {"bytes": data_bytes, "format": fmt}
 
     validation = validate(req.source_stats, synth_df)
+    validation["edgeCases"] = edge_case_report
+    if edge_case_report:
+        unmet = [r for r in edge_case_report if r["parsed"] and not r["satisfied"]]
+        unparsed = [r for r in edge_case_report if not r["parsed"]]
+        if unmet:
+            validation["insights"].append(
+                f"Edge case '{unmet[0]['description']}' fell short of its target — "
+                f"{unmet[0]['actualPct']}% vs {unmet[0]['targetPct']}% requested"
+            )
+        if unparsed:
+            validation["insights"].append(
+                f"{len(unparsed)} edge case{'s' if len(unparsed) > 1 else ''} could not be parsed — "
+                "rephrase using exact column names (e.g. 'hba1c > 12')"
+            )
+        if not unmet and not unparsed:
+            met = len(edge_case_report)
+            validation["insights"].append(
+                f"All {met} edge case{'s' if met > 1 else ''} enforced at requested coverage"
+            )
     file_size_kb = round(len(data_bytes) / 1024, 1)
     filename = f"aperture_output.{fmt}"
 

--- a/backend/services/edge_cases.py
+++ b/backend/services/edge_cases.py
@@ -1,0 +1,263 @@
+"""Parse natural-language edge case strings into structured, evaluable rules."""
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass, field
+from math import ceil
+from typing import Any
+
+import numpy as np
+import pandas as pd
+
+DEFAULT_TARGET_FRACTION = 0.05
+MAX_TARGET_FRACTION = 0.50
+
+_OP_ALIASES = {
+    "=": "==",
+    ">=": ">=",
+    "<=": "<=",
+    "==": "==",
+    "!=": "!=",
+    ">": ">",
+    "<": "<",
+}
+
+_COMPARE_RE = re.compile(
+    r"([A-Za-z_][A-Za-z0-9_]*)\s*(>=|<=|==|!=|=|>|<)\s*('([^']*)'|\"([^\"]*)\"|([-\d.]+|\w+))"
+)
+_AT_LEAST_RE = re.compile(r"(\d+)\s*\+\s*([A-Za-z_][A-Za-z0-9_]*)")
+_FRACTION_RE = re.compile(r"(\d+(?:\.\d+)?)\s*(?:%|percent)\s*(?:of)?")
+_PREFIX_RE = re.compile(r"^\s*edge\s*cases?\s*(?:for|of|where|:)?\s*", re.IGNORECASE)
+_SPLIT_RE = re.compile(r"\s+(?:and|with|,)\s+", re.IGNORECASE)
+
+
+@dataclass
+class Condition:
+    column: str
+    op: str
+    value: float | str
+
+    def mask(self, df: pd.DataFrame) -> pd.Series:
+        if self.column not in df.columns:
+            return pd.Series([False] * len(df), index=df.index)
+        s = df[self.column]
+        v = self.value
+        if isinstance(v, (int, float)):
+            s_num = pd.to_numeric(s, errors="coerce")
+            return _apply_op(s_num, self.op, v).fillna(False)
+        return _apply_op(s.astype(str), self.op, str(v))
+
+
+@dataclass
+class EdgeCaseRule:
+    description: str
+    conditions: list[Condition]
+    target_fraction: float = DEFAULT_TARGET_FRACTION
+    parsed: bool = True
+    parse_error: str | None = None
+
+    def mask(self, df: pd.DataFrame) -> pd.Series:
+        if not self.conditions:
+            return pd.Series([False] * len(df), index=df.index)
+        result = pd.Series([True] * len(df), index=df.index)
+        for cond in self.conditions:
+            result &= cond.mask(df)
+        return result
+
+
+def _apply_op(s: pd.Series, op: str, v) -> pd.Series:
+    if op == "==":
+        return s == v
+    if op == "!=":
+        return s != v
+    if op == ">":
+        return s > v
+    if op == "<":
+        return s < v
+    if op == ">=":
+        return s >= v
+    if op == "<=":
+        return s <= v
+    return pd.Series([False] * len(s), index=s.index)
+
+
+def _resolve_column(token: str, columns: list[str]) -> str | None:
+    token_low = token.lower()
+    for c in columns:
+        if c.lower() == token_low:
+            return c
+    for c in columns:
+        if c.lower().replace("_", "") == token_low.replace("_", ""):
+            return c
+    return None
+
+
+def _coerce_value(raw: str) -> float | str:
+    try:
+        if "." in raw:
+            return float(raw)
+        return float(int(raw))
+    except ValueError:
+        return raw.strip("'\"")
+
+
+def parse_edge_case(text: str, schema_columns: list[dict]) -> EdgeCaseRule:
+    """Parse a single NL edge case string into a structured rule.
+
+    Falls back to an empty (unparsed) rule with `parsed=False` if no conditions
+    could be extracted — callers should skip or surface these as warnings.
+    """
+    original = text
+    columns = [c["column"] for c in schema_columns]
+
+    target = DEFAULT_TARGET_FRACTION
+    frac_match = _FRACTION_RE.search(text)
+    if frac_match:
+        pct = float(frac_match.group(1)) / 100.0
+        target = max(0.0, min(MAX_TARGET_FRACTION, pct))
+        text = _FRACTION_RE.sub("", text, count=1)
+
+    text = _PREFIX_RE.sub("", text)
+    clauses = _SPLIT_RE.split(text)
+
+    conditions: list[Condition] = []
+    for clause in clauses:
+        clause = clause.strip(" .;:")
+        if not clause:
+            continue
+
+        m = _COMPARE_RE.search(clause)
+        if m:
+            col_token, op_raw, _, sq, dq, bare = m.groups()
+            col = _resolve_column(col_token, columns)
+            if col is None:
+                continue
+            raw_val = sq if sq is not None else dq if dq is not None else bare
+            conditions.append(Condition(column=col, op=_OP_ALIASES[op_raw], value=_coerce_value(raw_val)))
+            continue
+
+        am = _AT_LEAST_RE.search(clause)
+        if am:
+            n_raw, col_token = am.groups()
+            col = _resolve_column(col_token, columns)
+            if col is not None:
+                conditions.append(Condition(column=col, op=">=", value=float(int(n_raw))))
+
+    if not conditions:
+        return EdgeCaseRule(
+            description=original,
+            conditions=[],
+            target_fraction=target,
+            parsed=False,
+            parse_error="No recognizable conditions found",
+        )
+
+    return EdgeCaseRule(description=original, conditions=conditions, target_fraction=target)
+
+
+def parse_edge_cases(texts: list[str], schema_columns: list[dict]) -> list[EdgeCaseRule]:
+    return [parse_edge_case(t, schema_columns) for t in texts if t and t.strip()]
+
+
+def _satisfying_value(cond: Condition, stat: dict | None) -> Any:
+    """Produce a single value that satisfies `cond`, using source stats for realistic range."""
+    stat = stat or {}
+    if isinstance(cond.value, (int, float)):
+        v = float(cond.value)
+        col_min = float(stat.get("min", v - max(abs(v), 1.0)))
+        col_max = float(stat.get("max", v + max(abs(v), 1.0)))
+        eps = max(abs(v) * 0.01, 1e-6)
+        is_int = stat.get("col_type") == "int" or float(cond.value).is_integer()
+
+        if cond.op == "==":
+            out = v
+        elif cond.op == "!=":
+            out = col_max if col_max != v else col_min - 1
+        elif cond.op == ">":
+            hi = max(col_max, v + eps * 10)
+            out = float(np.random.uniform(v + eps, hi))
+        elif cond.op == ">=":
+            hi = max(col_max, v + eps * 10)
+            out = float(np.random.uniform(v, hi))
+        elif cond.op == "<":
+            lo = min(col_min, v - eps * 10)
+            out = float(np.random.uniform(lo, v - eps))
+        elif cond.op == "<=":
+            lo = min(col_min, v - eps * 10)
+            out = float(np.random.uniform(lo, v))
+        else:
+            out = v
+
+        if is_int:
+            if cond.op == ">":
+                return int(ceil(v + 1)) if v == int(v) else int(ceil(v))
+            if cond.op == "<":
+                return int(v) - 1 if v == int(v) else int(v)
+            return int(round(out))
+        return round(out, 4)
+
+    return cond.value
+
+
+def apply_edge_cases(
+    df: pd.DataFrame,
+    rules: list[EdgeCaseRule],
+    source_stats: dict[str, dict],
+) -> tuple[pd.DataFrame, list[dict]]:
+    """Enforce edge case rules in-place by overwriting constrained columns on selected rows.
+
+    Strategy: process rarest-target-first, claim rows so later rules prefer untouched rows,
+    and direct-assign satisfying values rather than rejection-sample for guaranteed coverage.
+    """
+    report: list[dict] = []
+    if df.empty or not rules:
+        return df, report
+
+    n = len(df)
+    ordered = sorted(rules, key=lambda r: r.target_fraction)
+    claimed: set = set()
+
+    for rule in ordered:
+        if not rule.parsed or not rule.conditions:
+            report.append({
+                "description": rule.description,
+                "parsed": False,
+                "error": rule.parse_error,
+                "targetPct": round(rule.target_fraction * 100, 2),
+                "actualPct": None,
+                "satisfied": False,
+            })
+            continue
+
+        target_count = max(1, int(ceil(rule.target_fraction * n)))
+        current_mask = rule.mask(df)
+        current_count = int(current_mask.sum())
+
+        if current_count < target_count:
+            needed = target_count - current_count
+            unsatisfied = [i for i in df.index if not bool(current_mask.loc[i])]
+            preferred = [i for i in unsatisfied if i not in claimed]
+            pool = preferred if len(preferred) >= needed else unsatisfied
+            take = min(needed, len(pool))
+            if take > 0:
+                chosen = np.random.choice(pool, size=take, replace=False)
+                for cond in rule.conditions:
+                    if cond.column not in df.columns:
+                        continue
+                    stat = source_stats.get(cond.column)
+                    for idx in chosen:
+                        df.at[idx, cond.column] = _satisfying_value(cond, stat)
+                claimed.update(int(i) for i in chosen)
+
+        final_count = int(rule.mask(df).sum())
+        report.append({
+            "description": rule.description,
+            "parsed": True,
+            "targetPct": round(rule.target_fraction * 100, 2),
+            "actualPct": round(final_count / n * 100, 2),
+            "targetCount": target_count,
+            "actualCount": final_count,
+            "satisfied": final_count >= target_count,
+        })
+
+    return df, report

--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -29,12 +29,24 @@ export interface ValidationColumnResult {
   note?: string;
 }
 
+export interface EdgeCaseResult {
+  description: string;
+  parsed: boolean;
+  targetPct: number;
+  actualPct: number | null;
+  targetCount?: number;
+  actualCount?: number;
+  satisfied: boolean;
+  error?: string;
+}
+
 export interface ValidationReportData {
   verdict: string;
   verdictStatus: 'pass' | 'warn' | 'fail';
   metrics: ValidationMetric[];
   columns: ValidationColumnResult[];
   insights: string[];
+  edgeCases?: EdgeCaseResult[];
 }
 
 export interface GenerateResponse {

--- a/frontend/src/components/workspace/ValidationReport.tsx
+++ b/frontend/src/components/workspace/ValidationReport.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useState } from 'react';
 import { Check, ChevronDown } from '../icons/Icons';
-import type { ValidationReport as ValidationReportType } from '../../constants/mockWorkspace';
+import type { ValidationReport as ValidationReportType, ValidationStatus } from '../../constants/mockWorkspace';
 
 interface Props {
   report: ValidationReportType;
@@ -113,6 +113,55 @@ export default function ValidationReport({ report }: Props) {
               )}
             </div>
           ))}
+        </div>
+      )}
+
+      {report.edgeCases && report.edgeCases.length > 0 && (
+        <div className="ws-edge-cases">
+          <div className="ws-edge-cases-label">Edge Case Enforcement</div>
+          {report.edgeCases.map((ec, i) => {
+            const status: ValidationStatus = !ec.parsed
+              ? 'warn'
+              : ec.satisfied
+                ? 'pass'
+                : 'fail';
+            const pct = ec.actualPct ?? 0;
+            const target = ec.targetPct;
+            return (
+              <div key={i} className="ws-edge-case-row">
+                <div className="ws-edge-case-top">
+                  <span className="ws-edge-case-desc">{ec.description}</span>
+                  <span className={`ws-validation-badge ws-validation-badge-${status}`}>
+                    {!ec.parsed ? 'Unparsed' : ec.satisfied ? 'Met' : 'Short'}
+                  </span>
+                </div>
+                {ec.parsed ? (
+                  <>
+                    <div className="ws-edge-case-bar-track">
+                      <div
+                        className={`ws-edge-case-bar ws-validation-bar-${status}`}
+                        style={{
+                          width: animated ? `${Math.min(100, (pct / Math.max(target, 0.01)) * 100)}%` : '0%',
+                        }}
+                      />
+                      <div
+                        className="ws-edge-case-target-marker"
+                        style={{ left: '100%' }}
+                      />
+                    </div>
+                    <div className="ws-edge-case-count">
+                      {ec.actualCount?.toLocaleString() ?? '—'} of{' '}
+                      {ec.targetCount?.toLocaleString() ?? '—'} target rows ({pct}% / {target}%)
+                    </div>
+                  </>
+                ) : (
+                  <div className="ws-edge-case-error">
+                    {ec.error ?? 'Could not parse — consider rephrasing with column names'}
+                  </div>
+                )}
+              </div>
+            );
+          })}
         </div>
       )}
 

--- a/frontend/src/constants/mockWorkspace.ts
+++ b/frontend/src/constants/mockWorkspace.ts
@@ -20,10 +20,22 @@ export interface EdgeCaseCoverage {
   coveragePct: number;
 }
 
+export interface EdgeCaseResult {
+  description: string;
+  parsed: boolean;
+  targetPct: number;
+  actualPct: number | null;
+  targetCount?: number;
+  actualCount?: number;
+  satisfied: boolean;
+  error?: string;
+}
+
 export interface ValidationReport {
   verdict: string;
   verdictStatus: ValidationStatus;
   edgeCaseCoverage?: EdgeCaseCoverage;
+  edgeCases?: EdgeCaseResult[];
   metrics: ValidationMetric[];
   columns: ValidationColumnResult[];
   insights: string[];

--- a/frontend/src/styles/workspace.css
+++ b/frontend/src/styles/workspace.css
@@ -653,6 +653,80 @@
   color: var(--text-dim);
 }
 
+/* Edge case enforcement (per-rule) */
+.ws-edge-cases {
+  padding: 14px 18px;
+  border-bottom: 1px solid var(--border);
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
+.ws-edge-cases-label {
+  font-size: 11px;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: var(--text-muted);
+  font-weight: 500;
+}
+
+.ws-edge-case-row {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+
+.ws-edge-case-top {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: 12px;
+}
+
+.ws-edge-case-desc {
+  font-family: var(--mono);
+  font-size: 12px;
+  color: var(--text);
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.ws-edge-case-bar-track {
+  position: relative;
+  height: 5px;
+  background: var(--bg);
+  border-radius: 3px;
+  overflow: hidden;
+}
+
+.ws-edge-case-bar {
+  height: 100%;
+  border-radius: 3px;
+  transition: width 0.6s ease;
+}
+
+.ws-edge-case-target-marker {
+  position: absolute;
+  top: -2px;
+  width: 2px;
+  height: 9px;
+  background: var(--text-dim);
+  transform: translateX(-1px);
+}
+
+.ws-edge-case-count {
+  font-size: 11px;
+  color: var(--text-dim);
+  font-family: var(--mono);
+}
+
+.ws-edge-case-error {
+  font-size: 11px;
+  color: var(--text-muted);
+  font-style: italic;
+}
+
 /* Metrics row */
 .ws-validation-metrics {
   display: grid;


### PR DESCRIPTION
Edge cases extracted from prompts (e.g. "hba1c > 12 with 3+ comorbidities") were captured in GenerationSpec but never applied during synthesis... this wires them through end-to-end so requested rare-condition rows actually appear in the output and are reported back to the user.

Backend:
- services/edge_cases.py: regex parser turns NL strings into structured rules (column/op/value conditions + target fraction); enforcer overwrites a random subset of rows with satisfying values, rarest-target-first
- api/generate.py: parse + apply rules in /preview and /generate; attach a per-rule coverage report to the validation payload and surface unmet or unparseable rules in the insights list

Frontend:
- ValidationReport: new "Edge Case Enforcement" panel renders each rule with Met / Short / Unparsed badge, coverage bar, and counts
- Types extended on both api/client.ts and constants/mockWorkspace.ts

Unparseable inputs (e.g. ambiguous "5% of orders refunded" with no column match) are reported with parsed=false rather than silently dropped — leaves room for an LLM fallback parser later.