### PR TITLE
added source-backed fidelity validation checks

### DIFF
--- a/backend/api/generate.py
+++ b/backend/api/generate.py
@@ -7,7 +7,7 @@ from datetime import datetime, timezone
 from fastapi import APIRouter, HTTPException
 from fastapi.responses import HTMLResponse, StreamingResponse
 
-from core.state import sessions
+from core.state import sessions, source_datasets
 from models.schemas import GenerateRequest
 from services.edge_cases import apply_edge_cases, parse_edge_cases
 from services.synthesis import synthesize
@@ -49,7 +49,8 @@ async def generate(req: GenerateRequest):
         synth_df.to_csv(buf, index=False)
         data_bytes = buf.getvalue()
 
-    validation = validate(req.source_stats, synth_df)
+    source_df = source_datasets.get(req.source_id) if req.source_id else None
+    validation = validate(req.source_stats, synth_df, source_df)
     validation["edgeCases"] = edge_case_report
     if edge_case_report:
         unmet = [r for r in edge_case_report if r["parsed"] and not r["satisfied"]]

--- a/backend/api/schema.py
+++ b/backend/api/schema.py
@@ -1,7 +1,10 @@
 """POST /api/infer-schema — profile uploaded files and fit an SDV model."""
+import uuid
+
 import pandas as pd
 from fastapi import APIRouter, File, UploadFile
 
+from core.state import source_datasets
 from core.io import read_upload
 from services.profile import profile_dataframe
 
@@ -19,4 +22,9 @@ async def infer_schema(files: list[UploadFile] = File(...)):
             return {"error": f"Could not read {f.filename}: {exc}"}
 
     df = pd.concat(dfs, ignore_index=True)
-    return profile_dataframe(df)
+    source_id = str(uuid.uuid4())
+    source_datasets[source_id] = df
+
+    payload = profile_dataframe(df)
+    payload["source_id"] = source_id
+    return payload

--- a/backend/core/state.py
+++ b/backend/core/state.py
@@ -5,3 +5,4 @@ Replace with S3 / a database for production deployments.
 
 sessions: dict[str, dict] = {}
 sdv_models: dict[str, dict] = {}
+source_datasets: dict[str, object] = {}

--- a/backend/models/schemas.py
+++ b/backend/models/schemas.py
@@ -15,3 +15,4 @@ class GenerateRequest(BaseModel):
     format: str = "csv"  # csv | jsonl | parquet
     edge_cases: list[str] = []
     model_id: str | None = None  # SDV model fitted during /api/infer-schema
+    source_id: str | None = None  # Source dataframe stored during /api/infer-schema

--- a/backend/services/validation.py
+++ b/backend/services/validation.py
@@ -9,33 +9,30 @@ from services.inference import EMAIL_RE, PHONE_RE, SSN_RE
 TAIL_QUANTILES = (0.90, 0.95, 0.99)
 TAIL_DRIFT_WARN_THRESHOLD = 0.25
 TAIL_DRIFT_FAIL_THRESHOLD = 0.50
+TARGET_COLUMN_CANDIDATES = ("fraud", "is_fraud", "fraud_label", "target", "label", "outcome", "risk_label")
+FEATURE_IMPORTANCE_TOP_N = 10
+FEATURE_IMPORTANCE_MAX_ROWS = 5_000
 
 #created a helper function to compare synthetic p90/p95/p99 against source p90/p95/p99 when available
 def validate_tail_preservation(col: str, stat: dict, synth_s: pd.Series) -> dict[str, Any] | None:
     if synth_s.empty:
         return None
-
     quantile_results = []
     drift_scores: list[float] = []
-
     for q in TAIL_QUANTILES:
         key = f"p{int(q * 100)}"
         if key not in stat:
             continue
-
         source_q = float(stat[key])
         synth_q = float(synth_s.quantile(q))
-
         drift = abs(synth_q - source_q) / (abs(source_q) + 1e-9)
         drift_scores.append(drift)
-
         if drift >= TAIL_DRIFT_FAIL_THRESHOLD:
             status = "fail"
         elif drift >= TAIL_DRIFT_WARN_THRESHOLD:
             status = "warn"
         else:
             status = "pass"
-
         quantile_results.append(
             {
                 "quantile": key,
@@ -45,20 +42,16 @@ def validate_tail_preservation(col: str, stat: dict, synth_s: pd.Series) -> dict
                 "status": status,
             }
         )
-
     if not quantile_results:
         return None
-
     avg_drift = float(np.mean(drift_scores)) if drift_scores else 0.0
     score = max(0, round(100 - avg_drift * 100))
-
     if any(r["status"] == "fail" for r in quantile_results):
         status = "fail"
     elif any(r["status"] == "warn" for r in quantile_results):
         status = "warn"
     else:
         status = "pass"
-
     return {
         "column": col,
         "score": score,
@@ -66,8 +59,7 @@ def validate_tail_preservation(col: str, stat: dict, synth_s: pd.Series) -> dict
         "checks": quantile_results,
     }
 #helper func that does per col drift using Kolmogorov–Smirnov test
-#currently inactive, did not call in validate as we need validate() to have source_df as input
-#once source_df is set into validate() we can use this to compare real vs synthetic numeric dist
+#called from validate when source_df is available to compare real vs synthetic numeric distributions
 def validate_ks_per_column_drift(
     col: str,
     source_df: pd.DataFrame | None,
@@ -75,7 +67,6 @@ def validate_ks_per_column_drift(
 ) -> dict[str, Any] | None:
     if source_df is None or col not in source_df.columns or synth_s.empty:
         return None
-
     try:
         from scipy.stats import ks_2samp
     except ImportError:
@@ -84,22 +75,17 @@ def validate_ks_per_column_drift(
             "status": "warn",
             "note": "scipy is not installed; KS test could not run",
         }
-
     source_s = pd.to_numeric(source_df[col], errors="coerce").dropna()
     synth_numeric = pd.to_numeric(synth_s, errors="coerce").dropna()
-
     if len(source_s) < 2 or len(synth_numeric) < 2:
         return None
-
     ks_stat, p_value = ks_2samp(source_s, synth_numeric)
-
     if p_value < 0.01:
         status = "fail"
     elif p_value < 0.05:
         status = "warn"
     else:
         status = "pass"
-
     return {
         "column": col,
         "ksStat": round(float(ks_stat), 4),
@@ -107,20 +93,19 @@ def validate_ks_per_column_drift(
         "status": status,
     }
 #another helper func that tests inter column correlation using mutual info score
-#function is not called yet not until we have a source_df
+#called from validate when source_df is available
 def validate_mutual_information_relationships(
     source_df: pd.DataFrame | None,
     synth_df: pd.DataFrame,
     max_pairs: int = 50,
 ) -> dict[str, Any] | None:
-    """Future-ready pairwise Mutual Information validation.
-    Purpose:
-    - Compare inter-column relationships in source vs. synthetic data.
-    - Uses normalized mutual information, which can capture nonlinear and categorical relationships.
+    """future-ready pairwise Mutual Information validation.
+    purpose:
+    - compare inter-column relationships in source vs. synthetic data.
+    - uses normalized mutual information, which can capture nonlinear and categorical relationships.
     """
     if source_df is None or source_df.empty or synth_df.empty:
         return None
-
     try:
         from sklearn.metrics import normalized_mutual_info_score
     except ImportError:
@@ -128,50 +113,39 @@ def validate_mutual_information_relationships(
             "status": "warn",
             "note": "scikit-learn is not installed; mutual information validation could not run",
         }
-
     shared_cols = [col for col in source_df.columns if col in synth_df.columns]
     if len(shared_cols) < 2:
         return None
-
     def discretize_series(s: pd.Series) -> pd.Series:
         """Convert numeric/categorical values into comparable discrete bins."""
         s = s.dropna()
-
         if pd.api.types.is_numeric_dtype(s):
             # qcut gives quantile bins, which helps compare nonlinear relationships safely.
             try:
                 return pd.qcut(s, q=min(10, max(2, s.nunique())), duplicates="drop").astype(str)
             except Exception:
                 return s.astype(str)
-
         return s.astype(str)
-
     pair_results = []
     drift_scores: list[float] = []
-
     pairs_checked = 0
     for i, col_a in enumerate(shared_cols):
         for col_b in shared_cols[i + 1:]:
             if pairs_checked >= max_pairs:
                 break
-
             source_pair = source_df[[col_a, col_b]].dropna()
             synth_pair = synth_df[[col_a, col_b]].dropna()
-
             if len(source_pair) < 5 or len(synth_pair) < 5:
                 continue
-
             source_a = discretize_series(source_pair[col_a])
             source_b = discretize_series(source_pair[col_b])
             synth_a = discretize_series(synth_pair[col_a])
             synth_b = discretize_series(synth_pair[col_b])
-
             # Align lengths after discretization/dropna.
             source_len = min(len(source_a), len(source_b))
             synth_len = min(len(synth_a), len(synth_b))
             if source_len < 5 or synth_len < 5:
                 continue
-
             source_mi = normalized_mutual_info_score(
                 source_a.iloc[:source_len],
                 source_b.iloc[:source_len],
@@ -180,17 +154,14 @@ def validate_mutual_information_relationships(
                 synth_a.iloc[:synth_len],
                 synth_b.iloc[:synth_len],
             )
-
             drift = abs(float(source_mi) - float(synth_mi))
             drift_scores.append(drift)
-
             if drift >= 0.50:
                 status = "fail"
             elif drift >= 0.25:
                 status = "warn"
             else:
                 status = "pass"
-
             pair_results.append(
                 {
                     "columns": [col_a, col_b],
@@ -200,31 +171,158 @@ def validate_mutual_information_relationships(
                     "status": status,
                 }
             )
-
             pairs_checked += 1
-
         if pairs_checked >= max_pairs:
             break
-
     if not pair_results:
         return None
-
     avg_drift = float(np.mean(drift_scores)) if drift_scores else 0.0
     score = max(0, round(100 - avg_drift * 100))
-
     if any(r["status"] == "fail" for r in pair_results):
         status = "fail"
     elif any(r["status"] == "warn" for r in pair_results):
         status = "warn"
     else:
         status = "pass"
-
     return {
         "score": score,
         "status": status,
         "pairsChecked": len(pair_results),
         "checks": pair_results,
     }
+
+
+def validate_feature_importance_overlap(
+    source_df: pd.DataFrame | None,
+    synth_df: pd.DataFrame,
+    top_n: int = FEATURE_IMPORTANCE_TOP_N,
+) -> dict[str, Any] | None:
+    if source_df is None or source_df.empty or synth_df.empty:
+        return None
+
+    shared_cols = [col for col in source_df.columns if col in synth_df.columns]
+    by_lower = {col.lower(): col for col in shared_cols}
+    target_col = next((by_lower[name] for name in TARGET_COLUMN_CANDIDATES if name in by_lower), None)
+    if target_col is None:
+        return None
+
+    feature_cols = [col for col in shared_cols if col != target_col]
+    if not feature_cols:
+        return None
+
+    try:
+        from sklearn.ensemble import RandomForestClassifier, RandomForestRegressor
+    except ImportError:
+        return {
+            "targetColumn": target_col,
+            "status": "warn",
+            "note": "scikit-learn is not installed; feature importance comparison could not run",
+        }
+
+    def is_classification_target(source_s: pd.Series, synth_s: pd.Series) -> bool:
+        combined = pd.concat([source_s, synth_s], ignore_index=True).dropna()
+        if pd.api.types.is_bool_dtype(combined) or pd.api.types.is_object_dtype(combined):
+            return True
+        if isinstance(combined.dtype, pd.CategoricalDtype):
+            return True
+        return bool(pd.api.types.is_numeric_dtype(combined) and combined.nunique() <= 20)
+
+    classification = is_classification_target(source_df[target_col], synth_df[target_col])
+
+    def build_xy(df: pd.DataFrame) -> tuple[pd.DataFrame, pd.Series] | None:
+        frame = df[feature_cols + [target_col]].copy()
+        frame = frame.dropna(subset=[target_col])
+        if len(frame) < 10:
+            return None
+        if len(frame) > FEATURE_IMPORTANCE_MAX_ROWS:
+            frame = frame.sample(FEATURE_IMPORTANCE_MAX_ROWS, random_state=42)
+
+        if classification:
+            y = frame[target_col].astype(str)
+        else:
+            y = pd.to_numeric(frame[target_col], errors="coerce")
+            frame = frame.loc[y.notna()].copy()
+            y = y.loc[frame.index].astype(float)
+            if len(frame) < 10:
+                return None
+
+        features = frame[feature_cols].copy()
+        for col in features.columns:
+            if pd.api.types.is_datetime64_any_dtype(features[col]):
+                features[col] = features[col].astype(str)
+        x = pd.get_dummies(features, dummy_na=True)
+        x = x.apply(pd.to_numeric, errors="coerce").replace([np.inf, -np.inf], np.nan).fillna(0)
+        if x.empty:
+            return None
+        return x, y
+
+    source_xy = build_xy(source_df)
+    synth_xy = build_xy(synth_df)
+    if source_xy is None or synth_xy is None:
+        return None
+
+    source_x, source_y = source_xy
+    synth_x, synth_y = synth_xy
+    source_x, synth_x = source_x.align(synth_x, join="outer", axis=1, fill_value=0)
+    if source_x.shape[1] == 0:
+        return None
+
+    if classification:
+        if source_y.nunique() < 2 or synth_y.nunique() < 2:
+            return None
+        source_model = RandomForestClassifier(n_estimators=50, random_state=42, min_samples_leaf=2)
+        synth_model = RandomForestClassifier(n_estimators=50, random_state=42, min_samples_leaf=2)
+        model_type = "classification"
+    else:
+        if source_y.nunique() < 2 or synth_y.nunique() < 2:
+            return None
+        source_model = RandomForestRegressor(n_estimators=50, random_state=42, min_samples_leaf=2)
+        synth_model = RandomForestRegressor(n_estimators=50, random_state=42, min_samples_leaf=2)
+        model_type = "regression"
+
+    try:
+        source_model.fit(source_x, source_y)
+        synth_model.fit(synth_x, synth_y)
+    except Exception as exc:
+        return {
+            "targetColumn": target_col,
+            "status": "warn",
+            "note": f"Feature importance comparison could not run: {exc}",
+        }
+
+    def top_features(importances: np.ndarray, columns: pd.Index) -> list[dict[str, Any]]:
+        ranked = sorted(zip(columns.astype(str), importances), key=lambda item: item[1], reverse=True)
+        return [
+            {"feature": feature, "importance": round(float(importance), 4)}
+            for feature, importance in ranked[:top_n]
+        ]
+
+    source_top = top_features(source_model.feature_importances_, source_x.columns)
+    synth_top = top_features(synth_model.feature_importances_, synth_x.columns)
+    source_names = [item["feature"] for item in source_top]
+    synth_names = [item["feature"] for item in synth_top]
+    overlap = sorted(set(source_names) & set(synth_names))
+    denominator = max(1, min(top_n, len(source_names), len(synth_names)))
+    overlap_score = round(len(overlap) / denominator, 4)
+    if overlap_score >= 0.70:
+        status = "pass"
+    elif overlap_score >= 0.40:
+        status = "warn"
+    else:
+        status = "fail"
+
+    return {
+        "targetColumn": target_col,
+        "modelType": model_type,
+        "topN": top_n,
+        "overlapScore": overlap_score,
+        "overlapFeatures": overlap,
+        "sourceTopFeatures": source_top,
+        "syntheticTopFeatures": synth_top,
+        "status": status,
+    }
+
+
 DUPLICATE_WARN_PCT = 1.0
 DUPLICATE_FAIL_PCT = 5.0
 MODE_DOMINANCE_WARN = 0.95
@@ -282,12 +380,18 @@ def check_low_diversity(synth_df: pd.DataFrame) -> list[dict[str, Any]]:
     return issues
 
 
-def validate(source_stats: dict[str, dict], synth_df: pd.DataFrame) -> dict:
+def validate(
+    source_stats: dict[str, dict],
+    synth_df: pd.DataFrame,
+    source_df: pd.DataFrame | None = None,
+) -> dict:
     col_results = []
     realism_scores: list[float] = []
     diversity_scores: list[float] = []
     #j
     tail_results: list[dict[str, Any]] = []
+    ks_results: list[dict[str, Any]] = []
+    source_available = source_df is not None and not source_df.empty
 
     for col, stat in source_stats.items():
         if col not in synth_df.columns:
@@ -317,6 +421,10 @@ def validate(source_stats: dict[str, dict], synth_df: pd.DataFrame) -> dict:
             tail_check = validate_tail_preservation(col, stat, synth_s)
             if tail_check:
                 tail_results.append(tail_check)
+            if source_available:
+                ks_check = validate_ks_per_column_drift(col, source_df, synth_s)
+                if ks_check:
+                    ks_results.append(ks_check)
 
         elif col_type == "enum":
             src_cats = set(stat.get("categories", []))
@@ -355,6 +463,16 @@ def validate(source_stats: dict[str, dict], synth_df: pd.DataFrame) -> dict:
 
     duplicates = check_duplicates(synth_df)
     diversity_issues = check_low_diversity(synth_df)
+    mi_relationships = (
+        validate_mutual_information_relationships(source_df, synth_df)
+        if source_available
+        else None
+    )
+    feature_importance = (
+        validate_feature_importance_overlap(source_df, synth_df)
+        if source_available
+        else None
+    )
 
     if duplicates["status"] == "fail":
         diversity = min(diversity, 60)
@@ -384,6 +502,39 @@ def validate(source_stats: dict[str, dict], synth_df: pd.DataFrame) -> dict:
         else:
             insights.append("Tail preservation checks passed for numeric columns with source quantiles")
 
+    if ks_results:
+        weak_ks_cols = [r for r in ks_results if r.get("status") in ("warn", "fail")]
+        if weak_ks_cols:
+            insights.append(
+                f"{weak_ks_cols[0]['column']} shows KS distribution drift — compare real vs synthetic numeric distributions"
+            )
+        else:
+            insights.append("KS distribution drift checks passed for numeric columns")
+
+    if mi_relationships:
+        if mi_relationships.get("note"):
+            insights.append(mi_relationships["note"])
+        elif mi_relationships["status"] in ("warn", "fail"):
+            insights.append(
+                "Mutual information drift detected — review inter-column relationships in the generated data"
+            )
+        else:
+            insights.append(
+                f"Mutual information checks passed across {mi_relationships['pairsChecked']} column pairs"
+            )
+
+    if feature_importance:
+        if feature_importance.get("note"):
+            insights.append(feature_importance["note"])
+        elif feature_importance["status"] in ("warn", "fail"):
+            insights.append(
+                f"Top feature importance overlap is {feature_importance['overlapScore']:.0%} for target '{feature_importance['targetColumn']}'"
+            )
+        else:
+            insights.append(
+                f"Top feature importance overlap passed at {feature_importance['overlapScore']:.0%} for target '{feature_importance['targetColumn']}'"
+            )
+
     if duplicates["status"] != "pass":
         insights.append(
             f"{duplicates['count']:,} duplicate row{'s' if duplicates['count'] != 1 else ''} "
@@ -400,7 +551,7 @@ def validate(source_stats: dict[str, dict], synth_df: pd.DataFrame) -> dict:
     )
 
     overall_pass = realism >= 85 and diversity >= 75 and safety >= 90
-    return {
+    result = {
         "verdict": "Ready for use" if overall_pass else "Review recommended",
         "verdictStatus": "pass" if overall_pass else "warn",
         "metrics": [
@@ -413,3 +564,10 @@ def validate(source_stats: dict[str, dict], synth_df: pd.DataFrame) -> dict:
         "duplicates": duplicates,
         "diversityIssues": diversity_issues,
     }
+    if ks_results:
+        result["ksDrift"] = ks_results
+    if mi_relationships:
+        result["mutualInformationRelationships"] = mi_relationships
+    if feature_importance:
+        result["featureImportanceComparison"] = feature_importance
+    return result

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -68,6 +68,7 @@ function App() {
   const [landingStats, setLandingStats] = useState<SourceStats | null>(null);
   const [landingSourceRows, setLandingSourceRows] = useState<number>(0);
   const [landingModelId, setLandingModelId] = useState<string | null>(null);
+  const [landingSourceId, setLandingSourceId] = useState<string | null>(null);
   const [schemaInferring, setSchemaInferring] = useState(false);
 
   const activeProfile = profiles.find((p) => p.id === selectedId) ?? profiles[0];
@@ -79,6 +80,7 @@ function App() {
       setLandingStats(null);
       setLandingSourceRows(0);
       setLandingModelId(null);
+      setLandingSourceId(null);
       return;
     }
     setSchemaInferring(true);
@@ -89,11 +91,19 @@ function App() {
         setLandingStats(result.stats);
         setLandingSourceRows(result.source_rows);
         setLandingModelId(result.model_id ?? null);
+        setLandingSourceId(result.source_id ?? null);
+      } else {
+        setLandingSchema(null);
+        setLandingStats(null);
+        setLandingSourceRows(0);
+        setLandingModelId(null);
+        setLandingSourceId(null);
       }
     } catch {
       setLandingSchema(null);
       setLandingStats(null);
       setLandingModelId(null);
+      setLandingSourceId(null);
     } finally {
       setSchemaInferring(false);
     }
@@ -130,6 +140,7 @@ function App() {
     let generationSpec: GenerationSpec | undefined;
     let schemaSource: 'llm' | 'upload' | undefined;
     let modelId: string | null = null;
+    let sourceId: string | null = null;
     let planData = buildExecutionPlan(sourceNames);
 
     const mongoIntegration = activeProfile.integrations.find(
@@ -269,13 +280,20 @@ function App() {
       // Use already-inferred schema if available, otherwise infer now
       const result =
         landingSchema && landingStats
-          ? { columns: landingSchema, stats: landingStats, source_rows: landingSourceRows, model_id: landingModelId }
+          ? {
+              columns: landingSchema,
+              stats: landingStats,
+              source_rows: landingSourceRows,
+              model_id: landingModelId,
+              source_id: landingSourceId ?? undefined,
+            }
           : await inferSchema(groundingFiles).catch(() => null);
 
       if (result) {
         schema = result.columns;
         stats = result.stats;
         modelId = result.model_id ?? null;
+        sourceId = result.source_id ?? null;
         schemaSource = 'upload';
         generationSpec = {
           row_count: 10_000,
@@ -297,6 +315,7 @@ function App() {
         schema = result.columns;
         stats = result.stats;
         modelId = result.model_id ?? null;
+        sourceId = result.source_id ?? null;
         schemaSource = 'upload';
         generationSpec = {
           row_count: 10_000,
@@ -339,6 +358,7 @@ function App() {
       generationSpec,
       schemaSource,
       modelId,
+      sourceId,
     });
   };
 
@@ -373,6 +393,7 @@ function App() {
     setLandingStats(null);
     setLandingSourceRows(0);
     setLandingModelId(null);
+    setLandingSourceId(null);
     setView('landing');
   };
 

--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -13,6 +13,7 @@ export interface InferSchemaResponse {
   stats: SourceStats;
   source_rows: number;
   model_id?: string | null;
+  source_id?: string;
   error?: string;
 }
 
@@ -144,6 +145,7 @@ export async function generate(
   format: 'csv' | 'jsonl' | 'parquet' = 'csv',
   edgeCases: string[] = [],
   modelId?: string | null,
+  sourceId?: string | null,
 ): Promise<GenerateResponse> {
   const res = await fetch(`${BASE}/generate`, {
     method: 'POST',
@@ -156,6 +158,7 @@ export async function generate(
       format,
       edge_cases: edgeCases,
       model_id: modelId ?? null,
+      source_id: sourceId ?? null,
     }),
   });
   if (!res.ok) throw new Error(`Generation failed: ${res.statusText}`);

--- a/frontend/src/components/workspace/AssistantMessage.tsx
+++ b/frontend/src/components/workspace/AssistantMessage.tsx
@@ -41,6 +41,7 @@ export default function AssistantMessage({
   generationSpec,
   schemaSource,
   modelId,
+  sourceId,
 }: Props) {
   const [approval, setApproval] = useState<ApprovalState>(initialApproval ?? 'idle');
   const [genResult, setGenResult] = useState<GenerateResponse | null>(null);
@@ -105,6 +106,7 @@ export default function AssistantMessage({
         format,
         generationSpec?.edge_cases ?? [],
         modelId,
+        sourceId,
       );
       setApproval('validating');
       await new Promise<void>((r) => window.setTimeout(r, 800));

--- a/frontend/src/constants/mockWorkspace.ts
+++ b/frontend/src/constants/mockWorkspace.ts
@@ -170,6 +170,7 @@ export type WorkspaceMessage =
       generationSpec?: GenerationSpec;
       schemaSource?: 'llm' | 'upload' | 'agent';
       modelId?: string | null;
+      sourceId?: string | null;
       host?: string;
     };
 


### PR DESCRIPTION
TLDR:

I added source-backed fidelity validation for file-grounded synthetic datasets.

The main change is wiring the uploaded source dataframe through the validation flow using a `source_id`, so validation can compare generated synthetic data against the original uploaded data when available.

Implemented validation checks:
- Per-column numeric drift using Kolmogorov-Smirnov tests
- Inter-column relationship validation using mutual information
- Top-N feature importance comparison between real vs synthetic data
- Existing tail preservation checks for p90 / p95 / p99 remain supported

What changes I made:

Backend:
- Added an in-memory `source_datasets` store in `backend/core/state.py`
- Updated `/api/infer-schema` to store uploaded source dataframes and return a `source_id`
- Added optional `source_id` to `GenerateRequest`
- Updated `/api/generate` to retrieve `source_df` when `source_id` is present
- Updated `validate()` to accept `source_df=None` for backward compatibility
- Added source-backed validation outputs:
  - `ksDrift`
  - `mutualInformationRelationships`
  - `featureImportanceComparison`

Frontend:
- Added `source_id` to schema inference response typing
- Stored `sourceId` in frontend state
- Passed `sourceId` into the generate request when available

Backward compatibility:

Prompt-only generation still works. If no `source_id` or `source_df` is available, the new validation checks are skipped gracefully and the existing validation flow still runs.

Tested I have done locally to verify:
- Frontend build passed with `npm run build`
- Backend server successfully started 
- Prompt-only generation did not crash
- File-grounded generation with an uploaded auto insurance claims CSV completed successfully
- Validation report surfaced:
   - KS distribution drift
   - Mutual information drift
   - Top feature importance overlap for `fraud_label`
