### PR TITLE
Render experiment diagnostics in the Trust Report

### DIFF
--- a/backend/services/diagnostics.py
+++ b/backend/services/diagnostics.py
@@ -1,0 +1,538 @@
+"""Experiment diagnostics: confusion matrices, observations, recommendations.
+
+Runs after compute_utility. Re-trains models independently from utility.py so this
+module owns its blast radius. Returns None when utility couldn't be computed
+(no real data, no label column, etc.).
+
+Phase 1 scope: confusion matrices (TRTR / TSTR / TR+STR), observation-style findings
+phrased as facts not diagnoses, templated recommendations. Per-feature ablation and
+misclassification overlap land in Phase 3.
+"""
+from __future__ import annotations
+
+from typing import Any
+
+import numpy as np
+import pandas as pd
+from sklearn.model_selection import train_test_split
+from sklearn.preprocessing import LabelEncoder
+
+try:
+    from xgboost import XGBClassifier
+    _XGB_AVAILABLE = True
+except ImportError:
+    _XGB_AVAILABLE = False
+
+
+DEFAULT_RANDOM_STATE = 42
+
+# Heuristic thresholds (in percentage points, on AUC or recall).
+HIGH_AUC_GAP_PCT = 15
+MODERATE_AUC_GAP_PCT = 5
+STRONG_RECALL_LIFT_PCT = 5
+RECALL_DROP_PCT = 3
+
+# Same heuristic as utility.py — keep these in sync if either is edited.
+_LABEL_NAMES = (
+    "fraud_reported", "fraud", "FraudFound", "FraudFound_P",
+    "label", "target", "y", "is_fraud", "class",
+)
+
+
+def _detect_label_column(df: pd.DataFrame) -> str | None:
+    for c in _LABEL_NAMES:
+        if c in df.columns:
+            return c
+    return None
+
+
+def _encode(
+    df: pd.DataFrame,
+    encoders: dict[str, LabelEncoder] | None = None,
+) -> tuple[pd.DataFrame, dict[str, LabelEncoder]]:
+    """Label-encode object columns. Unknown categories collapse to -1."""
+    encoders = encoders or {}
+    out = df.copy()
+    for col in out.select_dtypes(include="object").columns:
+        if col not in encoders:
+            encoders[col] = LabelEncoder()
+            out[col] = encoders[col].fit_transform(out[col].astype(str))
+        else:
+            known = set(encoders[col].classes_)
+            enc = encoders[col]
+            out[col] = out[col].astype(str).map(lambda v: enc.transform([v])[0] if v in known else -1)
+    return out, encoders
+
+
+def _binarize_label(s: pd.Series) -> pd.Series:
+    """Normalise 'Y'/'N', 'Yes'/'No', True/False to int 0/1."""
+    if s.dtype == object:
+        return s.astype(str).str.upper().isin(["Y", "YES", "TRUE", "1"]).astype(int)
+    return s.astype(int)
+
+
+def _prep(
+    real_df: pd.DataFrame,
+    synth_df: pd.DataFrame,
+    label_col: str,
+) -> dict[str, Any] | None:
+    """Mirror utility.py's prep so diagnostics trains on the exact same split shape.
+
+    Returns None if the inputs can't be used (no common columns, single-class label, etc.).
+    """
+    real = real_df.dropna(subset=[label_col]).copy()
+    real[label_col] = _binarize_label(real[label_col])
+    if real[label_col].nunique() < 2:
+        return None
+
+    synth = synth_df.copy()
+    if label_col in synth.columns:
+        synth[label_col] = _binarize_label(synth[label_col])
+    else:
+        return None
+    if synth[label_col].nunique() < 2:
+        return None
+
+    common = [c for c in real.columns if c in synth.columns and c != label_col]
+    if not common:
+        return None
+
+    X_real = real[common]
+    y_real = real[label_col].values
+    X_train_raw, X_test_raw, y_train, y_test = train_test_split(
+        X_real, y_real, test_size=0.2, stratify=y_real, random_state=DEFAULT_RANDOM_STATE
+    )
+
+    X_train, encoders = _encode(X_train_raw)
+    X_test, _ = _encode(X_test_raw, encoders)
+    X_synth, _ = _encode(synth[common], encoders)
+    y_synth = synth[label_col].astype(int).values
+
+    return {
+        "X_train": X_train.values, "X_test": X_test.values,
+        "y_train": y_train, "y_test": y_test,
+        "X_synth": X_synth.values, "y_synth": y_synth,
+        "feature_names": common,
+        "encoders": encoders,
+    }
+
+
+def _train(X_train: np.ndarray, y_train: np.ndarray) -> XGBClassifier | None:
+    """Train an XGBoost classifier with scale_pos_weight balancing for class imbalance."""
+    if not _XGB_AVAILABLE or len(np.unique(y_train)) < 2:
+        return None
+    spw = max(1.0, (y_train == 0).sum() / max((y_train == 1).sum(), 1))
+    clf = XGBClassifier(
+        n_estimators=200, max_depth=4, learning_rate=0.1,
+        scale_pos_weight=spw, eval_metric="logloss",
+        verbosity=0, random_state=DEFAULT_RANDOM_STATE, n_jobs=1,
+    )
+    clf.fit(X_train, y_train)
+    return clf
+
+
+def _confusion(y_true: np.ndarray, y_pred: np.ndarray) -> dict[str, int]:
+    """Binary confusion matrix. tn=true-neg, fp=false-pos, fn=false-neg, tp=true-pos."""
+    tn = int(((y_true == 0) & (y_pred == 0)).sum())
+    fp = int(((y_true == 0) & (y_pred == 1)).sum())
+    fn = int(((y_true == 1) & (y_pred == 0)).sum())
+    tp = int(((y_true == 1) & (y_pred == 1)).sum())
+    return {"tn": tn, "fp": fp, "fn": fn, "tp": tp}
+
+
+def _predict(clf: XGBClassifier | None, X: np.ndarray) -> np.ndarray | None:
+    if clf is None:
+        return None
+    proba = clf.predict_proba(X)[:, 1]
+    return (proba > 0.5).astype(int)
+
+
+def _train_three_regimes(prep: dict) -> dict[str, Any] | None:
+    """Train TRTR / TSTR / TR+STR. Returns classifiers + predictions + confusion matrices,
+    so downstream analyses (ablation, misclass overlap) can reuse the trained models."""
+    trtr_clf = _train(prep["X_train"], prep["y_train"])
+    tstr_clf = _train(prep["X_synth"], prep["y_synth"])
+
+    X_aug = np.vstack([prep["X_train"], prep["X_synth"]])
+    y_aug = np.concatenate([prep["y_train"], prep["y_synth"]])
+    aug_clf = _train(X_aug, y_aug)
+
+    classifiers = {"trtr": trtr_clf, "tstr": tstr_clf, "augmented": aug_clf}
+    preds: dict[str, np.ndarray] = {}
+    conf: dict[str, dict[str, int]] = {}
+    for name, clf in classifiers.items():
+        p = _predict(clf, prep["X_test"])
+        if p is None:
+            return None
+        preds[name] = p
+        conf[name] = _confusion(prep["y_test"], p)
+    return {"classifiers": classifiers, "predictions": preds, "confusion": conf}
+
+
+def _feature_importance(clf: XGBClassifier, feature_names: list[str], top_k: int = 8) -> list[tuple[int, str, float]]:
+    """Return the top-K features by gain importance, as (index, name, importance) tuples."""
+    importances = clf.feature_importances_
+    order = np.argsort(importances)[::-1][:top_k]
+    return [(int(i), feature_names[i], float(importances[i])) for i in order]
+
+
+def _recall(y_true: np.ndarray, y_pred: np.ndarray) -> float:
+    pos = (y_true == 1)
+    return float(y_pred[pos].mean()) if pos.any() else 0.0
+
+
+def _compute_ablation(
+    clf: XGBClassifier | None,
+    X_test: np.ndarray,
+    y_test: np.ndarray,
+    feature_names: list[str],
+    top_k: int = 8,
+) -> list[dict[str, Any]]:
+    """Permutation feature importance against the augmented model.
+
+    For each top-K feature (by gain), shuffle that column in X_test and measure how much
+    the augmented model's recall drops. Large positive drop => model relies on that feature.
+    Capped at top_k features to bound runtime to roughly N * inference cost.
+    """
+    if clf is None or len(y_test) == 0:
+        return []
+    rng = np.random.default_rng(DEFAULT_RANDOM_STATE)
+    baseline_pred = _predict(clf, X_test)
+    if baseline_pred is None:
+        return []
+    baseline_recall = _recall(y_test, baseline_pred)
+
+    top = _feature_importance(clf, feature_names, top_k=top_k)
+    out: list[dict[str, Any]] = []
+    for idx, name, importance in top:
+        X_permuted = X_test.copy()
+        X_permuted[:, idx] = rng.permutation(X_permuted[:, idx])
+        permuted_pred = _predict(clf, X_permuted)
+        if permuted_pred is None:
+            continue
+        permuted_recall = _recall(y_test, permuted_pred)
+        delta_pct = round((baseline_recall - permuted_recall) * 100, 1)
+        if delta_pct >= 5:
+            interpretation = "high reliance"
+        elif delta_pct >= 1:
+            interpretation = "useful"
+        elif delta_pct >= -1:
+            interpretation = "marginal"
+        else:
+            interpretation = "harmful when present"
+        out.append({
+            "feature": name,
+            "importance": round(importance, 4),
+            "recall_delta_pct": delta_pct,
+            "baseline_recall": round(baseline_recall, 4),
+            "permuted_recall": round(permuted_recall, 4),
+            "interpretation": interpretation,
+        })
+    return out
+
+
+def _compute_misclass_overlap(
+    y_test: np.ndarray,
+    preds: dict[str, np.ndarray],
+) -> dict[str, Any]:
+    """Compare which test rows each regime gets wrong.
+
+    Returns counts plus row indices in four buckets:
+      - tstr_only_wrong:  TRTR got these right, TSTR didn't  → synthetic hurts here
+      - trtr_only_wrong:  TSTR got these right, TRTR didn't  → synthetic helps here
+      - both_wrong:       Neither regime got them            → genuinely hard rows
+      - augmentation_only_correct: AUG correct AND at least one of TRTR/TSTR wrong → augmentation saves
+    """
+    trtr_wrong = (preds["trtr"] != y_test)
+    tstr_wrong = (preds["tstr"] != y_test)
+    aug_wrong = (preds["augmented"] != y_test)
+
+    tstr_only = np.where(tstr_wrong & ~trtr_wrong)[0]
+    trtr_only = np.where(trtr_wrong & ~tstr_wrong)[0]
+    both = np.where(trtr_wrong & tstr_wrong)[0]
+    aug_saves = np.where(~aug_wrong & (trtr_wrong | tstr_wrong))[0]
+
+    # Keep up to 5 example row indices per bucket for the report.
+    cap = 5
+    n_help = int(len(trtr_only))
+    n_hurt = int(len(tstr_only))
+    if n_help >= n_hurt + 5:
+        summary = f"Synthetic helps on {n_help} rows where real-only failed; hurts on {n_hurt} rows where real-only succeeded — net positive contribution."
+    elif n_hurt >= n_help + 5:
+        summary = f"Synthetic hurts on {n_hurt} rows; only helps on {n_help} — net negative contribution at the current synthetic distribution."
+    else:
+        summary = f"Synthetic helps on {n_help} rows and hurts on {n_hurt} — roughly neutral row-level contribution."
+
+    return {
+        "tstr_only_wrong": [int(i) for i in tstr_only[:cap]],
+        "trtr_only_wrong": [int(i) for i in trtr_only[:cap]],
+        "both_wrong": [int(i) for i in both[:cap]],
+        "augmentation_saves": [int(i) for i in aug_saves[:cap]],
+        "counts": {
+            "tstr_only_wrong": int(len(tstr_only)),
+            "trtr_only_wrong": int(len(trtr_only)),
+            "both_wrong": int(len(both)),
+            "augmentation_saves": int(len(aug_saves)),
+            "total_test_rows": int(len(y_test)),
+        },
+        "summary": summary,
+    }
+
+
+def _gap_pct(a: float | None, b: float | None) -> float | None:
+    """Percentage-point gap (a - b) * 100, or None if either input is None/NaN."""
+    if a is None or b is None or np.isnan(a) or np.isnan(b):
+        return None
+    return round((a - b) * 100, 1)
+
+
+def _fn_rate(c: dict[str, int]) -> float:
+    pos = c["tp"] + c["fn"]
+    return c["fn"] / pos if pos > 0 else 0.0
+
+
+def _fp_rate(c: dict[str, int]) -> float:
+    neg = c["tn"] + c["fp"]
+    return c["fp"] / neg if neg > 0 else 0.0
+
+
+def _build_ablation_observations(ablation: list[dict]) -> list[str]:
+    """Observations driven by per-feature ablation findings."""
+    obs: list[str] = []
+    if not ablation:
+        return obs
+    top = max(ablation, key=lambda a: a["recall_delta_pct"])
+    harmful = [a for a in ablation if a["recall_delta_pct"] <= -3]
+
+    if top["recall_delta_pct"] >= 5:
+        obs.append(
+            f"Augmented model relies heavily on '{top['feature']}' — permuting it drops recall by "
+            f"{top['recall_delta_pct']}pt. Verify its synthetic distribution looks right before trusting the model."
+        )
+    if harmful:
+        names = ", ".join(f"'{a['feature']}'" for a in harmful[:2])
+        obs.append(
+            f"Permuting {names} actually improved recall — these features may be noisy or harmful "
+            f"in the current synthetic distribution."
+        )
+    return obs
+
+
+def _build_misclass_observations(misclass: dict) -> list[str]:
+    """Observations driven by row-level misclassification overlap."""
+    obs: list[str] = []
+    if not misclass:
+        return obs
+    c = misclass.get("counts", {})
+    saves = c.get("augmentation_saves", 0)
+    total = max(c.get("total_test_rows", 1), 1)
+    if saves > 0:
+        obs.append(
+            f"Augmentation correctly classifies {saves} of {total} test rows that at least one of "
+            f"real-only or synthetic-only got wrong — measurable row-level benefit from combining the two."
+        )
+    return obs
+
+
+def _build_observations(
+    utility: dict,
+    conf: dict[str, dict[str, int]],
+) -> list[str]:
+    """Observation-style findings — facts derived from numbers, never diagnostic claims."""
+    obs: list[str] = []
+    trtr_auc = (utility.get("trtr") or {}).get("auc")
+    tstr_auc = (utility.get("tstr") or {}).get("auc")
+    aug_auc = (utility.get("augmented") or {}).get("auc")
+    recall_lift = utility.get("recall_lift_pct")
+
+    # AUC gap (TRTR vs TSTR) — magnitude of synthetic-only underperformance.
+    gap_auc = _gap_pct(trtr_auc, tstr_auc)
+    if gap_auc is not None:
+        if gap_auc >= HIGH_AUC_GAP_PCT:
+            obs.append(
+                f"TSTR AUC is {gap_auc}pt below TRTR — synthetic-only training significantly "
+                f"underperforms real-only on the held-out test set."
+            )
+        elif gap_auc >= MODERATE_AUC_GAP_PCT:
+            obs.append(
+                f"TSTR AUC is {gap_auc}pt below TRTR — synthetic-only training moderately "
+                f"underperforms; consider augmentation rather than replacement."
+            )
+        elif gap_auc >= 0:
+            obs.append(
+                f"TSTR AUC is within {gap_auc}pt of TRTR — synthetic-only training is "
+                f"comparable to real-only on this test set."
+            )
+        else:
+            obs.append(
+                f"TSTR AUC is {abs(gap_auc)}pt above TRTR — synthetic data appears to add signal "
+                f"beyond what the real training split contains."
+            )
+
+    # Augmentation lift — does adding synthetic to real help?
+    if recall_lift is not None:
+        if recall_lift >= STRONG_RECALL_LIFT_PCT:
+            obs.append(
+                f"Real + synthetic training improves rare-class recall by {recall_lift}pt vs "
+                f"real-only — strong augmentation signal."
+            )
+        elif recall_lift >= 0:
+            obs.append(
+                f"Real + synthetic training marginally improves rare-class recall ({recall_lift}pt) "
+                f"vs real-only — augmentation helps but the effect is small."
+            )
+        elif recall_lift <= -RECALL_DROP_PCT:
+            obs.append(
+                f"Real + synthetic training reduces rare-class recall by {abs(recall_lift)}pt vs "
+                f"real-only — augmentation is harmful at the current synthetic distribution."
+            )
+
+    # Augmented AUC vs TRTR — best-of-both signal.
+    gap_aug = _gap_pct(aug_auc, trtr_auc)
+    if gap_aug is not None and gap_aug >= MODERATE_AUC_GAP_PCT:
+        obs.append(
+            f"Augmented training (real + synthetic) outperforms real-only by {gap_aug}pt AUC — "
+            f"the synthetic data is contributing complementary information."
+        )
+
+    # False-negative / false-positive shifts between regimes.
+    trtr_fn, tstr_fn, aug_fn = _fn_rate(conf["trtr"]), _fn_rate(conf["tstr"]), _fn_rate(conf["augmented"])
+    trtr_fp, tstr_fp, aug_fp = _fp_rate(conf["trtr"]), _fp_rate(conf["tstr"]), _fp_rate(conf["augmented"])
+
+    if tstr_fn - trtr_fn > 0.05:
+        delta = round((tstr_fn - trtr_fn) * 100, 1)
+        obs.append(
+            f"Synthetic-only training misses {delta}pt more positive cases than real-only "
+            f"(higher false-negative rate) — the rare class is under-represented in synthetic."
+        )
+    if tstr_fp - trtr_fp > 0.05:
+        delta = round((tstr_fp - trtr_fp) * 100, 1)
+        obs.append(
+            f"Synthetic-only training overflags {delta}pt more negative cases than real-only "
+            f"(higher false-positive rate) — synthetic positive examples may be too aggressive."
+        )
+    if trtr_fn - aug_fn > 0.05:
+        delta = round((trtr_fn - aug_fn) * 100, 1)
+        obs.append(
+            f"Augmentation reduces false negatives by {delta}pt vs real-only — "
+            f"synthetic minority examples help the model catch real positives."
+        )
+
+    return obs
+
+
+def _build_recommendations(
+    utility: dict,
+    conf: dict[str, dict[str, int]],
+    n_synth: int,
+) -> list[str]:
+    """Templated next-iteration recommendations driven by the same heuristics."""
+    recs: list[str] = []
+    trtr_auc = (utility.get("trtr") or {}).get("auc")
+    tstr_auc = (utility.get("tstr") or {}).get("auc")
+    recall_lift = utility.get("recall_lift_pct")
+    gap_auc = _gap_pct(trtr_auc, tstr_auc)
+
+    # Augmentation is the recommended training regime when it lifts the metric.
+    if recall_lift is not None and recall_lift > 0:
+        recs.append(
+            "Train production models on real + synthetic (TR+STR) rather than synthetic-only — "
+            "augmentation is contributing measurable lift on this test set."
+        )
+
+    if gap_auc is not None and gap_auc >= HIGH_AUC_GAP_PCT:
+        recs.append(
+            "Do not train production models on synthetic data alone — the AUC gap to real-only "
+            "training is too large. Use synthetic only to augment a real-data baseline."
+        )
+
+    # Volume-based: if synthetic-only underperforms moderately, more rows might close the gap.
+    if gap_auc is not None and gap_auc >= MODERATE_AUC_GAP_PCT and n_synth < 10_000:
+        recs.append(
+            f"Re-generate with a larger row count (current synthetic = {n_synth:,}) to reduce "
+            "the synthetic-vs-real performance gap. Aperture caps at 100,000 rows per generation."
+        )
+
+    # False-positive surplus → tone down the minority oversampling.
+    tstr_fp = _fp_rate(conf["tstr"])
+    trtr_fp = _fp_rate(conf["trtr"])
+    if tstr_fp - trtr_fp > 0.05:
+        recs.append(
+            "Synthetic-only training overflags negatives — consider lowering the edge-case target "
+            "fraction for the positive class or rephrasing the rule to a narrower condition."
+        )
+
+    # False-negative surplus → minority class is under-represented in synthetic.
+    tstr_fn = _fn_rate(conf["tstr"])
+    trtr_fn = _fn_rate(conf["trtr"])
+    if tstr_fn - trtr_fn > 0.05:
+        recs.append(
+            "Synthetic minority-class coverage looks thin — add or strengthen an edge case targeting "
+            "the positive label (e.g. '10% of fraud_reported == Y') and regenerate."
+        )
+
+    # Always include a fixed-seed reproducibility note for users iterating.
+    recs.append(
+        "Re-running generation will produce slightly different metrics due to sampling. "
+        "If you need a fixed benchmark, regenerate twice and compare to estimate variance."
+    )
+
+    return recs
+
+
+def compute_diagnostics(
+    real_df: pd.DataFrame | None,
+    synth_df: pd.DataFrame,
+    utility: dict[str, Any] | None = None,
+    label_col: str | None = None,
+) -> dict[str, Any] | None:
+    """Run experiment diagnostics on top of an existing utility report.
+
+    Returns None when utility itself is unavailable — there's nothing to diagnose without it.
+    """
+    if utility is None or not utility.get("available"):
+        return None
+    if real_df is None or len(real_df) < 50:
+        return None
+
+    label = label_col or utility.get("target") or _detect_label_column(real_df)
+    if label is None or label not in synth_df.columns:
+        return None
+
+    prep = _prep(real_df, synth_df, label)
+    if prep is None:
+        return None
+
+    trained = _train_three_regimes(prep)
+    if trained is None:
+        return None
+
+    conf = trained["confusion"]
+    preds = trained["predictions"]
+    aug_clf = trained["classifiers"]["augmented"]
+
+    # Per-feature ablation on the augmented model (top-K by feature importance).
+    feature_ablation = _compute_ablation(
+        aug_clf, prep["X_test"], prep["y_test"], prep["feature_names"], top_k=8,
+    )
+
+    # Row-level overlap: where does each regime get test rows wrong?
+    misclass_overlap = _compute_misclass_overlap(prep["y_test"], preds)
+
+    observations = (
+        _build_observations(utility, conf)
+        + _build_ablation_observations(feature_ablation)
+        + _build_misclass_observations(misclass_overlap)
+    )
+    recommendations = _build_recommendations(utility, conf, len(synth_df))
+
+    return {
+        "available": True,
+        "target": label,
+        "n_test": int(len(prep["y_test"])),
+        "confusion_matrices": conf,
+        "feature_ablation": feature_ablation,
+        "misclassification_overlap": misclass_overlap,
+        "observations": observations,
+        "recommendations": recommendations,
+    }

--- a/backend/services/trust_report.py
+++ b/backend/services/trust_report.py
@@ -529,6 +529,8 @@ def _render_diagnostics_section(diagnostics: dict | None) -> str:
     conf = diagnostics.get("confusion_matrices", {}) or {}
     observations = diagnostics.get("observations", []) or []
     recommendations = diagnostics.get("recommendations", []) or []
+    ablation = diagnostics.get("feature_ablation", []) or []
+    misclass = diagnostics.get("misclassification_overlap") or {}
 
     # Three confusion matrices side by side: TRTR / TSTR / TR+STR.
     matrix_specs = [
@@ -569,6 +571,79 @@ def _render_diagnostics_section(diagnostics: dict | None) -> str:
         )
     matrices_block = f'<div class="conf-matrices">{"".join(matrix_html)}</div>'
 
+    # Feature ablation — horizontal bar chart of recall delta per feature.
+    if ablation:
+        # Scale bars relative to the largest absolute delta in this run.
+        max_abs = max((abs(a["recall_delta_pct"]) for a in ablation), default=1.0) or 1.0
+        ab_rows = []
+        for a in ablation:
+            delta = a["recall_delta_pct"]
+            width = min(100, abs(delta) / max_abs * 100)
+            if delta >= 5:
+                tone = "pass"     # high reliance — useful feature
+            elif delta >= 1:
+                tone = "warn"
+            elif delta >= -1:
+                tone = "info"     # marginal
+            else:
+                tone = "fail"     # harmful
+            sign = "+" if delta >= 0 else ""
+            ab_rows.append(
+                f'<div class="abl-row">'
+                f'<div class="abl-name mono">{escape(a["feature"])}</div>'
+                f'<div class="abl-bar-track">'
+                f'<div class="abl-bar abl-bar-{tone}" style="width:{width}%"></div>'
+                f'</div>'
+                f'<div class="abl-delta num">{sign}{delta}pt</div>'
+                f'<div class="abl-tag muted">{escape(a["interpretation"])}</div>'
+                f'</div>'
+            )
+        ablation_block = (
+            '<div class="diag-subsection">'
+            '<h3>Feature Ablation (Augmented Model)</h3>'
+            '<div class="muted" style="margin-bottom:10px; font-size:11px;">'
+            'Recall drop when each top-importance feature is permuted in the test set. '
+            'Larger drops = model relies on that feature.'
+            '</div>'
+            '<div class="abl-list">' + "".join(ab_rows) + '</div>'
+            '</div>'
+        )
+    else:
+        ablation_block = ""
+
+    # Misclassification overlap — counts per bucket.
+    if misclass and misclass.get("counts"):
+        c = misclass["counts"]
+        buckets = [
+            ("Synthetic helps", c.get("trtr_only_wrong", 0), "pass",
+             "Test rows real-only got wrong but synthetic-only got right"),
+            ("Synthetic hurts", c.get("tstr_only_wrong", 0), "fail",
+             "Test rows real-only got right but synthetic-only got wrong"),
+            ("Both wrong", c.get("both_wrong", 0), "warn",
+             "Genuinely hard rows neither regime classifies correctly"),
+            ("Augmentation saves", c.get("augmentation_saves", 0), "pass",
+             "Augmented model correct where at least one base regime failed"),
+        ]
+        bucket_cards = "".join(
+            f'<div class="mc-card mc-card-{tone}">'
+            f'<div class="mc-name">{escape(name)}</div>'
+            f'<div class="mc-count">{count:,}</div>'
+            f'<div class="mc-desc muted">{escape(desc)}</div>'
+            f'</div>'
+            for name, count, tone, desc in buckets
+        )
+        misclass_block = (
+            '<div class="diag-subsection">'
+            '<h3>Row-Level Misclassification Overlap</h3>'
+            '<div class="muted" style="margin-bottom:10px; font-size:11px;">'
+            f'{escape(misclass.get("summary", ""))}'
+            '</div>'
+            f'<div class="mc-grid">{bucket_cards}</div>'
+            '</div>'
+        )
+    else:
+        misclass_block = ""
+
     obs_html = (
         '<ul class="diag-list">'
         + "".join(f'<li>{escape(o)}</li>' for o in observations)
@@ -588,6 +663,8 @@ def _render_diagnostics_section(diagnostics: dict | None) -> str:
         f'Each matrix shows model performance on the same {n_test:,} real test rows.'
         f'</div>'
         f'{matrices_block}'
+        f'{ablation_block}'
+        f'{misclass_block}'
         f'<div class="diag-subsection">'
         f'<h3>Observations</h3>'
         f'{obs_html}'
@@ -925,6 +1002,52 @@ def render_html_report(session: dict) -> str:
   }}
   .diag-list, .diag-list-num {{ margin: 0; padding-left: 20px; }}
   .diag-list li, .diag-list-num li {{ margin-bottom: 6px; font-size: 13px; }}
+  .abl-list {{ display: flex; flex-direction: column; gap: 6px; }}
+  .abl-row {{
+    display: grid;
+    grid-template-columns: 160px 1fr 70px 130px;
+    align-items: center;
+    gap: 10px;
+    font-size: 12px;
+  }}
+  .abl-name {{ font-size: 12px; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }}
+  .abl-bar-track {{
+    height: 8px;
+    background: var(--bg);
+    border-radius: 4px;
+    overflow: hidden;
+  }}
+  .abl-bar {{ height: 100%; border-radius: 4px; }}
+  .abl-bar-pass {{ background: #7a9a6d; }}
+  .abl-bar-warn {{ background: #c89b3c; }}
+  .abl-bar-info {{ background: #6b7a8f; }}
+  .abl-bar-fail {{ background: #c0524a; }}
+  .abl-delta {{ text-align: right; font-family: var(--mono); font-size: 12px; }}
+  .abl-tag {{ font-size: 11px; }}
+  .mc-grid {{
+    display: grid;
+    grid-template-columns: repeat(4, 1fr);
+    gap: 10px;
+  }}
+  .mc-card {{
+    background: var(--surface);
+    border: 1px solid var(--border);
+    border-left: 3px solid var(--border);
+    padding: 12px 14px;
+    border-radius: 4px;
+  }}
+  .mc-card-pass {{ border-left-color: #7a9a6d; }}
+  .mc-card-warn {{ border-left-color: #c89b3c; }}
+  .mc-card-fail {{ border-left-color: #c0524a; }}
+  .mc-name {{
+    font-size: 10px;
+    letter-spacing: 0.08em;
+    text-transform: uppercase;
+    color: var(--text-muted);
+    font-weight: 500;
+  }}
+  .mc-count {{ font-family: var(--mono); font-size: 22px; margin: 6px 0; color: var(--text); }}
+  .mc-desc {{ font-size: 11px; line-height: 1.4; }}
   .metric-card {{
     background: var(--surface);
     border: 1px solid var(--border);

--- a/backend/services/trust_report.py
+++ b/backend/services/trust_report.py
@@ -516,6 +516,89 @@ def _render_audit_section(audit: dict | None) -> str:
     )
 
 
+def _render_diagnostics_section(diagnostics: dict | None) -> str:
+    """Experiment diagnostics: confusion matrices + observations + recommendations."""
+    if diagnostics is None or not diagnostics.get("available"):
+        return (
+            '<p class="muted">Experiment diagnostics unavailable. Requires a real source dataset '
+            'with a label column so Aperture can compute confusion matrices on a held-out test set.</p>'
+        )
+
+    target = diagnostics.get("target", "?")
+    n_test = diagnostics.get("n_test", 0)
+    conf = diagnostics.get("confusion_matrices", {}) or {}
+    observations = diagnostics.get("observations", []) or []
+    recommendations = diagnostics.get("recommendations", []) or []
+
+    # Three confusion matrices side by side: TRTR / TSTR / TR+STR.
+    matrix_specs = [
+        ("trtr",      "Real only",        "TRTR"),
+        ("tstr",      "Synthetic only",   "TSTR"),
+        ("augmented", "Real + Synthetic", "TR+STR"),
+    ]
+    matrix_html = []
+    for key, name, abbrev in matrix_specs:
+        c = conf.get(key) or {}
+        tn, fp, fn, tp = c.get("tn", 0), c.get("fp", 0), c.get("fn", 0), c.get("tp", 0)
+        total = tn + fp + fn + tp
+        def _pct(n: int, total: int = total) -> str:
+            return f"{round(n / total * 100, 1)}%" if total > 0 else "—"
+        matrix_html.append(
+            f'<div class="conf-matrix">'
+            f'<div class="conf-label">{escape(name)} <span class="muted">({abbrev})</span></div>'
+            f'<table class="conf-grid">'
+            f'<tr><th></th><th class="conf-head">Pred 0</th><th class="conf-head">Pred 1</th></tr>'
+            f'<tr><th class="conf-head">True 0</th>'
+            f'<td class="conf-cell conf-correct">'
+            f'<div class="conf-n">{tn:,}</div><div class="conf-pct">{_pct(tn)}</div>'
+            f'<div class="conf-tag">TN</div></td>'
+            f'<td class="conf-cell conf-fp">'
+            f'<div class="conf-n">{fp:,}</div><div class="conf-pct">{_pct(fp)}</div>'
+            f'<div class="conf-tag">FP</div></td>'
+            f'</tr>'
+            f'<tr><th class="conf-head">True 1</th>'
+            f'<td class="conf-cell conf-fn">'
+            f'<div class="conf-n">{fn:,}</div><div class="conf-pct">{_pct(fn)}</div>'
+            f'<div class="conf-tag">FN</div></td>'
+            f'<td class="conf-cell conf-correct">'
+            f'<div class="conf-n">{tp:,}</div><div class="conf-pct">{_pct(tp)}</div>'
+            f'<div class="conf-tag">TP</div></td>'
+            f'</tr>'
+            f'</table>'
+            f'</div>'
+        )
+    matrices_block = f'<div class="conf-matrices">{"".join(matrix_html)}</div>'
+
+    obs_html = (
+        '<ul class="diag-list">'
+        + "".join(f'<li>{escape(o)}</li>' for o in observations)
+        + '</ul>'
+    ) if observations else '<p class="muted">No notable observations.</p>'
+
+    rec_html = (
+        '<ol class="diag-list-num">'
+        + "".join(f'<li>{escape(r)}</li>' for r in recommendations)
+        + '</ol>'
+    ) if recommendations else '<p class="muted">No specific recommendations.</p>'
+
+    return (
+        f'<div class="muted" style="margin-bottom: 12px; font-size: 11px;">'
+        f'Target: <span class="mono">{escape(str(target))}</span> · '
+        f'Held-out test set: {n_test:,} real rows · '
+        f'Each matrix shows model performance on the same {n_test:,} real test rows.'
+        f'</div>'
+        f'{matrices_block}'
+        f'<div class="diag-subsection">'
+        f'<h3>Observations</h3>'
+        f'{obs_html}'
+        f'</div>'
+        f'<div class="diag-subsection">'
+        f'<h3>Recommendations</h3>'
+        f'{rec_html}'
+        f'</div>'
+    )
+
+
 def render_html_report(session: dict) -> str:
     """Render a self-contained, printable HTML report for one generated dataset."""
     validation = session.get("validation", {}) or {}
@@ -537,10 +620,12 @@ def render_html_report(session: dict) -> str:
     utility = session.get("utility")
     rule_pack = session.get("rule_pack")
     audit = session.get("audit")
+    diagnostics = session.get("diagnostics")
 
     utility_section = _render_utility_section(utility)
     rule_pack_section = _render_rule_pack_section(rule_pack)
     audit_section = _render_audit_section(audit)
+    diagnostics_section = _render_diagnostics_section(diagnostics)
 
     # Metrics cards
     metric_cards = "".join(
@@ -772,6 +857,74 @@ def render_html_report(session: dict) -> str:
     margin-bottom: 8px;
   }}
   .utility-lift {{ display: flex; align-items: center; gap: 8px; font-size: 13px; }}
+  .conf-matrices {{
+    display: grid;
+    grid-template-columns: repeat(3, 1fr);
+    gap: 14px;
+    margin-bottom: 18px;
+  }}
+  .conf-matrix {{
+    background: var(--surface);
+    border: 1px solid var(--border);
+    padding: 12px;
+    border-radius: 4px;
+    text-align: center;
+  }}
+  .conf-label {{
+    font-size: 11px;
+    letter-spacing: 0.06em;
+    text-transform: uppercase;
+    color: var(--text-muted);
+    margin-bottom: 10px;
+    font-weight: 500;
+  }}
+  .conf-grid {{
+    width: 100%;
+    border-collapse: collapse;
+    font-size: 11px;
+  }}
+  .conf-grid th {{
+    color: var(--text-dim);
+    font-weight: 500;
+    padding: 4px;
+    font-family: var(--mono);
+    border: none;
+  }}
+  .conf-head {{
+    font-size: 10px;
+    letter-spacing: 0.06em;
+    text-transform: uppercase;
+  }}
+  .conf-cell {{
+    padding: 10px 6px;
+    border: 1px solid var(--border);
+    font-family: var(--mono);
+    position: relative;
+  }}
+  .conf-correct {{ background: rgba(122, 154, 109, 0.12); }}
+  .conf-fp {{ background: rgba(200, 155, 60, 0.14); }}
+  .conf-fn {{ background: rgba(192, 82, 74, 0.14); }}
+  .conf-n {{ font-size: 16px; color: var(--text); }}
+  .conf-pct {{ font-size: 10px; color: var(--text-muted); margin-top: 2px; }}
+  .conf-tag {{
+    position: absolute;
+    top: 3px;
+    right: 5px;
+    font-size: 9px;
+    color: var(--text-dim);
+    letter-spacing: 0.05em;
+  }}
+  .diag-subsection {{ margin-top: 18px; }}
+  .diag-subsection h3 {{
+    font-size: 11px;
+    letter-spacing: 0.1em;
+    text-transform: uppercase;
+    color: var(--text-muted);
+    font-weight: 500;
+    margin: 0 0 8px;
+  }}
+  .diag-list, .diag-list-num {{ margin: 0; padding-left: 20px; }}
+  .diag-list li, .diag-list-num li {{ margin-bottom: 6px; font-size: 13px; }}
   .metric-card {{
     background: var(--surface);
     border: 1px solid var(--border);
@@ -910,6 +1063,11 @@ def render_html_report(session: dict) -> str:
   <section>
     <h2>Downstream Utility</h2>
     {utility_section}
+  </section>
+
+  <section>
+    <h2>Experiment Diagnostics</h2>
+    {diagnostics_section}
   </section>
 
   <section>

--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -65,6 +65,52 @@ export interface ValidationReportData {
   diversityIssues?: DiversityIssue[];
 }
 
+export interface ConfusionMatrix {
+  tn: number;
+  fp: number;
+  fn: number;
+  tp: number;
+}
+
+export interface FeatureAblationEntry {
+  feature: string;
+  importance: number;
+  recall_delta_pct: number;
+  baseline_recall: number;
+  permuted_recall: number;
+  interpretation: 'high reliance' | 'useful' | 'marginal' | 'harmful when present';
+}
+
+export interface MisclassificationOverlap {
+  tstr_only_wrong: number[];
+  trtr_only_wrong: number[];
+  both_wrong: number[];
+  augmentation_saves: number[];
+  counts: {
+    tstr_only_wrong: number;
+    trtr_only_wrong: number;
+    both_wrong: number;
+    augmentation_saves: number;
+    total_test_rows: number;
+  };
+  summary: string;
+}
+
+export interface DiagnosticsReport {
+  available: boolean;
+  target?: string;
+  n_test?: number;
+  confusion_matrices?: {
+    trtr: ConfusionMatrix;
+    tstr: ConfusionMatrix;
+    augmented: ConfusionMatrix;
+  };
+  feature_ablation?: FeatureAblationEntry[];
+  misclassification_overlap?: MisclassificationOverlap;
+  observations?: string[];
+  recommendations?: string[];
+}
+
 export interface GenerateResponse {
   session_id: string;
   row_count: number;
@@ -72,6 +118,7 @@ export interface GenerateResponse {
   format?: string;
   filename?: string;
   validation: ValidationReportData;
+  diagnostics?: DiagnosticsReport | null;
 }
 
 export interface ClarifyingQuestion {

--- a/frontend/src/components/workspace/AssistantMessage.tsx
+++ b/frontend/src/components/workspace/AssistantMessage.tsx
@@ -6,6 +6,7 @@ import GroundingStrategy from './GroundingStrategy';
 import SchemaCard from './SchemaCard';
 import SchemaInferenceProgress from './SchemaInferenceProgress';
 import ValidationReport from './ValidationReport';
+import DiagnosticsPanel from './DiagnosticsPanel';
 import ClarifyingQuestions from './ClarifyingQuestions';
 import PreviewTable from './PreviewTable';
 import { Download, FileIcon } from '../icons/Icons';
@@ -296,6 +297,7 @@ export default function AssistantMessage({
                         )}
                       </div>
                       <ValidationReport report={report} />
+                      <DiagnosticsPanel diagnostics={genResult?.diagnostics} />
                     </>
                   )}
                 </div>

--- a/frontend/src/components/workspace/DiagnosticsPanel.tsx
+++ b/frontend/src/components/workspace/DiagnosticsPanel.tsx
@@ -1,0 +1,271 @@
+import { useEffect, useState } from 'react';
+import type {
+  DiagnosticsReport,
+  ConfusionMatrix,
+  FeatureAblationEntry,
+} from '../../api/client';
+
+interface Props {
+  diagnostics: DiagnosticsReport | null | undefined;
+}
+
+type Tone = 'pass' | 'warn' | 'fail' | 'info';
+
+function pct(n: number, total: number): string {
+  if (total <= 0) return '—';
+  return `${Math.round((n / total) * 1000) / 10}%`;
+}
+
+function interpretationTone(interpretation: FeatureAblationEntry['interpretation']): Tone {
+  if (interpretation === 'high reliance') return 'pass';
+  if (interpretation === 'useful') return 'warn';
+  if (interpretation === 'marginal') return 'info';
+  return 'fail'; // harmful when present
+}
+
+function ConfusionGrid({
+  label,
+  abbrev,
+  matrix,
+}: {
+  label: string;
+  abbrev: string;
+  matrix: ConfusionMatrix;
+}) {
+  const total = matrix.tn + matrix.fp + matrix.fn + matrix.tp;
+  return (
+    <div className="dp-conf-matrix">
+      <div className="dp-conf-label">
+        {label} <span className="dp-muted">({abbrev})</span>
+      </div>
+      <table className="dp-conf-grid">
+        <thead>
+          <tr>
+            <th></th>
+            <th className="dp-conf-head">Pred 0</th>
+            <th className="dp-conf-head">Pred 1</th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr>
+            <th className="dp-conf-head">True 0</th>
+            <td className="dp-conf-cell dp-conf-correct">
+              <div className="dp-conf-n">{matrix.tn.toLocaleString()}</div>
+              <div className="dp-conf-pct">{pct(matrix.tn, total)}</div>
+              <div className="dp-conf-tag">TN</div>
+            </td>
+            <td className="dp-conf-cell dp-conf-fp">
+              <div className="dp-conf-n">{matrix.fp.toLocaleString()}</div>
+              <div className="dp-conf-pct">{pct(matrix.fp, total)}</div>
+              <div className="dp-conf-tag">FP</div>
+            </td>
+          </tr>
+          <tr>
+            <th className="dp-conf-head">True 1</th>
+            <td className="dp-conf-cell dp-conf-fn">
+              <div className="dp-conf-n">{matrix.fn.toLocaleString()}</div>
+              <div className="dp-conf-pct">{pct(matrix.fn, total)}</div>
+              <div className="dp-conf-tag">FN</div>
+            </td>
+            <td className="dp-conf-cell dp-conf-correct">
+              <div className="dp-conf-n">{matrix.tp.toLocaleString()}</div>
+              <div className="dp-conf-pct">{pct(matrix.tp, total)}</div>
+              <div className="dp-conf-tag">TP</div>
+            </td>
+          </tr>
+        </tbody>
+      </table>
+    </div>
+  );
+}
+
+function AblationBars({
+  ablation,
+  animated,
+}: {
+  ablation: FeatureAblationEntry[];
+  animated: boolean;
+}) {
+  const maxAbs = Math.max(1, ...ablation.map((a) => Math.abs(a.recall_delta_pct)));
+  return (
+    <div className="dp-abl-list">
+      {ablation.map((a) => {
+        const tone = interpretationTone(a.interpretation);
+        const width = Math.min(100, (Math.abs(a.recall_delta_pct) / maxAbs) * 100);
+        const sign = a.recall_delta_pct >= 0 ? '+' : '';
+        return (
+          <div key={a.feature} className="dp-abl-row">
+            <div className="dp-abl-name dp-mono" title={a.feature}>
+              {a.feature}
+            </div>
+            <div className="dp-abl-bar-track">
+              <div
+                className={`dp-abl-bar dp-bar-${tone}`}
+                style={{ width: animated ? `${width}%` : '0%' }}
+              />
+            </div>
+            <div className="dp-abl-delta dp-mono">
+              {sign}
+              {a.recall_delta_pct}pt
+            </div>
+            <div className="dp-abl-tag dp-muted">{a.interpretation}</div>
+          </div>
+        );
+      })}
+    </div>
+  );
+}
+
+function MisclassCards({
+  overlap,
+}: {
+  overlap: NonNullable<DiagnosticsReport['misclassification_overlap']>;
+}) {
+  const c = overlap.counts;
+  const buckets: Array<{ name: string; count: number; tone: Tone; desc: string }> = [
+    {
+      name: 'Synthetic helps',
+      count: c.trtr_only_wrong,
+      tone: 'pass',
+      desc: 'Real-only got these wrong; synthetic-only got them right',
+    },
+    {
+      name: 'Synthetic hurts',
+      count: c.tstr_only_wrong,
+      tone: 'fail',
+      desc: 'Real-only got these right; synthetic-only got them wrong',
+    },
+    {
+      name: 'Both wrong',
+      count: c.both_wrong,
+      tone: 'warn',
+      desc: 'Genuinely hard rows neither regime classifies correctly',
+    },
+    {
+      name: 'Augmentation saves',
+      count: c.augmentation_saves,
+      tone: 'pass',
+      desc: 'Augmented model correct where at least one base regime failed',
+    },
+  ];
+
+  return (
+    <div className="dp-mc-grid">
+      {buckets.map((b) => (
+        <div key={b.name} className={`dp-mc-card dp-mc-card-${b.tone}`}>
+          <div className="dp-mc-name">{b.name}</div>
+          <div className="dp-mc-count">{b.count.toLocaleString()}</div>
+          <div className="dp-mc-desc dp-muted">{b.desc}</div>
+        </div>
+      ))}
+    </div>
+  );
+}
+
+export default function DiagnosticsPanel({ diagnostics }: Props) {
+  const [expanded, setExpanded] = useState(true);
+  const [animated, setAnimated] = useState(false);
+
+  useEffect(() => {
+    const t = window.setTimeout(() => setAnimated(true), 60);
+    return () => window.clearTimeout(t);
+  }, []);
+
+  if (!diagnostics || !diagnostics.available) {
+    return (
+      <div className="dp-card">
+        <div className="dp-header">
+          <span className="dp-title">Experiment Diagnostics</span>
+          <span className="dp-badge dp-badge-info">Unavailable</span>
+        </div>
+        <div className="dp-empty">
+          Requires a real source dataset with a label column. Upload data via the integrations
+          panel and re-generate to enable confusion matrices, feature ablation, and row-level
+          misclassification overlap.
+        </div>
+      </div>
+    );
+  }
+
+  const target = diagnostics.target ?? '?';
+  const nTest = diagnostics.n_test ?? 0;
+  const conf = diagnostics.confusion_matrices;
+  const ablation = diagnostics.feature_ablation ?? [];
+  const overlap = diagnostics.misclassification_overlap;
+  const observations = diagnostics.observations ?? [];
+  const recommendations = diagnostics.recommendations ?? [];
+
+  return (
+    <div className="dp-card">
+      <button
+        type="button"
+        className="dp-header dp-header-button"
+        onClick={() => setExpanded((e) => !e)}
+        aria-expanded={expanded}
+      >
+        <span className="dp-title">Experiment Diagnostics</span>
+        <span className="dp-meta">
+          Target: <span className="dp-mono">{target}</span> · {nTest.toLocaleString()} held-out
+          test rows
+        </span>
+        <span className={`dp-chevron${expanded ? ' dp-chevron-open' : ''}`}>▾</span>
+      </button>
+
+      {expanded && (
+        <div className="dp-body">
+          {conf && (
+            <div className="dp-section">
+              <div className="dp-section-label">Confusion Matrices</div>
+              <div className="dp-conf-matrices">
+                <ConfusionGrid label="Real only" abbrev="TRTR" matrix={conf.trtr} />
+                <ConfusionGrid label="Synthetic only" abbrev="TSTR" matrix={conf.tstr} />
+                <ConfusionGrid label="Real + Synthetic" abbrev="TR+STR" matrix={conf.augmented} />
+              </div>
+            </div>
+          )}
+
+          {ablation.length > 0 && (
+            <div className="dp-section">
+              <div className="dp-section-label">Feature Ablation (Augmented Model)</div>
+              <div className="dp-section-hint">
+                Recall drop when each top-importance feature is permuted in the test set. Larger
+                drops = model relies on that feature.
+              </div>
+              <AblationBars ablation={ablation} animated={animated} />
+            </div>
+          )}
+
+          {overlap && overlap.counts && (
+            <div className="dp-section">
+              <div className="dp-section-label">Row-Level Misclassification Overlap</div>
+              <div className="dp-section-hint">{overlap.summary}</div>
+              <MisclassCards overlap={overlap} />
+            </div>
+          )}
+
+          {observations.length > 0 && (
+            <div className="dp-section">
+              <div className="dp-section-label">Observations</div>
+              <ul className="dp-list">
+                {observations.map((o, i) => (
+                  <li key={i}>{o}</li>
+                ))}
+              </ul>
+            </div>
+          )}
+
+          {recommendations.length > 0 && (
+            <div className="dp-section">
+              <div className="dp-section-label">Recommendations</div>
+              <ol className="dp-list-num">
+                {recommendations.map((r, i) => (
+                  <li key={i}>{r}</li>
+                ))}
+              </ol>
+            </div>
+          )}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/frontend/src/styles/workspace.css
+++ b/frontend/src/styles/workspace.css
@@ -1632,3 +1632,269 @@
 .schema-progress.phase-done .schema-progress-bar-fill {
   background: rgba(120, 200, 120, 0.7);
 }
+
+/* ── Diagnostics Panel ─────────────────────────────────────────────── */
+
+.dp-card {
+  margin-top: 16px;
+  background: var(--surface);
+  border: 1px solid var(--border);
+  border-radius: 12px;
+  overflow: hidden;
+}
+
+.dp-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+  padding: 14px 18px;
+  border-bottom: 1px solid var(--border);
+}
+
+.dp-header-button {
+  width: 100%;
+  background: none;
+  border: none;
+  color: inherit;
+  cursor: pointer;
+  font: inherit;
+  text-align: left;
+}
+
+.dp-header-button:hover { background: rgba(255, 255, 255, 0.02); }
+
+.dp-title {
+  font-size: 13px;
+  font-weight: 500;
+  color: var(--text);
+  letter-spacing: 0.02em;
+}
+
+.dp-meta {
+  font-size: 11px;
+  color: var(--text-muted);
+  font-family: var(--mono);
+}
+
+.dp-chevron {
+  font-size: 12px;
+  color: var(--text-dim);
+  transition: transform 0.2s ease;
+}
+
+.dp-chevron-open { transform: rotate(180deg); }
+
+.dp-badge {
+  display: inline-block;
+  padding: 2px 8px;
+  border-radius: 10px;
+  font-size: 10px;
+  letter-spacing: 0.06em;
+  font-weight: 500;
+}
+
+.dp-badge-info {
+  background: rgba(107, 122, 143, 0.16);
+  color: #9aa6b8;
+}
+
+.dp-empty {
+  padding: 18px;
+  font-size: 12px;
+  color: var(--text-muted);
+  line-height: 1.5;
+}
+
+.dp-body {
+  padding: 14px 18px 18px;
+  display: flex;
+  flex-direction: column;
+  gap: 18px;
+}
+
+.dp-section {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.dp-section-label {
+  font-size: 11px;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: var(--text-muted);
+  font-weight: 500;
+}
+
+.dp-section-hint {
+  font-size: 11px;
+  color: var(--text-muted);
+  line-height: 1.5;
+}
+
+.dp-mono { font-family: var(--mono); }
+.dp-muted { color: var(--text-muted); font-size: 12px; }
+
+/* Confusion matrices */
+.dp-conf-matrices {
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  gap: 12px;
+}
+
+.dp-conf-matrix {
+  background: var(--bg);
+  border: 1px solid var(--border);
+  border-radius: 8px;
+  padding: 10px;
+  text-align: center;
+}
+
+.dp-conf-label {
+  font-size: 10px;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+  color: var(--text-muted);
+  margin-bottom: 8px;
+  font-weight: 500;
+}
+
+.dp-conf-grid {
+  width: 100%;
+  border-collapse: collapse;
+  font-size: 11px;
+}
+
+.dp-conf-grid th {
+  color: var(--text-dim);
+  font-weight: 500;
+  padding: 3px;
+  font-family: var(--mono);
+  border: none;
+  background: none;
+}
+
+.dp-conf-head {
+  font-size: 9px !important;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+}
+
+.dp-conf-cell {
+  padding: 8px 4px;
+  border: 1px solid var(--border);
+  font-family: var(--mono);
+  position: relative;
+}
+
+.dp-conf-correct { background: rgba(122, 154, 109, 0.12); }
+.dp-conf-fp { background: rgba(200, 155, 60, 0.14); }
+.dp-conf-fn { background: rgba(192, 82, 74, 0.14); }
+
+.dp-conf-n { font-size: 14px; color: var(--text); }
+.dp-conf-pct { font-size: 9px; color: var(--text-muted); margin-top: 1px; }
+
+.dp-conf-tag {
+  position: absolute;
+  top: 2px;
+  right: 4px;
+  font-size: 8px;
+  color: var(--text-dim);
+  letter-spacing: 0.05em;
+}
+
+/* Feature ablation bars */
+.dp-abl-list {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+
+.dp-abl-row {
+  display: grid;
+  grid-template-columns: 140px 1fr 60px 110px;
+  align-items: center;
+  gap: 10px;
+  font-size: 12px;
+}
+
+.dp-abl-name {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  color: var(--text);
+}
+
+.dp-abl-bar-track {
+  height: 7px;
+  background: var(--bg);
+  border-radius: 4px;
+  overflow: hidden;
+}
+
+.dp-abl-bar {
+  height: 100%;
+  border-radius: 4px;
+  transition: width 0.6s ease;
+}
+
+.dp-bar-pass { background: #7a9a6d; }
+.dp-bar-warn { background: #c89b3c; }
+.dp-bar-info { background: #6b7a8f; }
+.dp-bar-fail { background: #c0524a; }
+
+.dp-abl-delta { text-align: right; font-size: 12px; }
+.dp-abl-tag { font-size: 11px; }
+
+/* Misclassification overlap cards */
+.dp-mc-grid {
+  display: grid;
+  grid-template-columns: repeat(4, 1fr);
+  gap: 10px;
+}
+
+.dp-mc-card {
+  background: var(--bg);
+  border: 1px solid var(--border);
+  border-left: 3px solid var(--border);
+  padding: 12px;
+  border-radius: 6px;
+}
+
+.dp-mc-card-pass { border-left-color: #7a9a6d; }
+.dp-mc-card-warn { border-left-color: #c89b3c; }
+.dp-mc-card-fail { border-left-color: #c0524a; }
+
+.dp-mc-name {
+  font-size: 10px;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: var(--text-muted);
+  font-weight: 500;
+}
+
+.dp-mc-count {
+  font-family: var(--mono);
+  font-size: 20px;
+  margin: 6px 0 4px;
+  color: var(--text);
+}
+
+.dp-mc-desc {
+  font-size: 11px;
+  line-height: 1.4;
+}
+
+/* Lists */
+.dp-list, .dp-list-num {
+  margin: 0;
+  padding-left: 20px;
+  font-size: 13px;
+  color: var(--text);
+}
+
+.dp-list li, .dp-list-num li {
+  margin-bottom: 6px;
+  line-height: 1.5;
+}


### PR DESCRIPTION
Adds Experiment Diagnostics section to the printable trust report. Shows three confusion matrices side by side (TRTR / TSTR / TR+STR) on the same held-out test set, color-coded by cell type (TN/TP green, FP amber, FN red). Follows with observation-style findings and templated recommendations.

Graceful null when diagnostics aren't available (no real source data or no label column) / section renders a single explanatory line instead of broken matrices.

Stacks on feat/trust-report-utility. The backend module that populates session.diagnostics lives in feat/diagnostics-phase-1. Reviewer-friendly merge order: trust-report-utility → diagnostics-phase-1 → this PR.