### PR TITLE
Add DiagnosticsPanel to the workspace UI

### DIFF
--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -65,6 +65,52 @@ export interface ValidationReportData {
   diversityIssues?: DiversityIssue[];
 }
 
+export interface ConfusionMatrix {
+  tn: number;
+  fp: number;
+  fn: number;
+  tp: number;
+}
+
+export interface FeatureAblationEntry {
+  feature: string;
+  importance: number;
+  recall_delta_pct: number;
+  baseline_recall: number;
+  permuted_recall: number;
+  interpretation: 'high reliance' | 'useful' | 'marginal' | 'harmful when present';
+}
+
+export interface MisclassificationOverlap {
+  tstr_only_wrong: number[];
+  trtr_only_wrong: number[];
+  both_wrong: number[];
+  augmentation_saves: number[];
+  counts: {
+    tstr_only_wrong: number;
+    trtr_only_wrong: number;
+    both_wrong: number;
+    augmentation_saves: number;
+    total_test_rows: number;
+  };
+  summary: string;
+}
+
+export interface DiagnosticsReport {
+  available: boolean;
+  target?: string;
+  n_test?: number;
+  confusion_matrices?: {
+    trtr: ConfusionMatrix;
+    tstr: ConfusionMatrix;
+    augmented: ConfusionMatrix;
+  };
+  feature_ablation?: FeatureAblationEntry[];
+  misclassification_overlap?: MisclassificationOverlap;
+  observations?: string[];
+  recommendations?: string[];
+}
+
 export interface GenerateResponse {
   session_id: string;
   row_count: number;
@@ -72,6 +118,7 @@ export interface GenerateResponse {
   format?: string;
   filename?: string;
   validation: ValidationReportData;
+  diagnostics?: DiagnosticsReport | null;
 }
 
 export interface ClarifyingQuestion {

--- a/frontend/src/components/workspace/AssistantMessage.tsx
+++ b/frontend/src/components/workspace/AssistantMessage.tsx
@@ -6,6 +6,7 @@ import GroundingStrategy from './GroundingStrategy';
 import SchemaCard from './SchemaCard';
 import SchemaInferenceProgress from './SchemaInferenceProgress';
 import ValidationReport from './ValidationReport';
+import DiagnosticsPanel from './DiagnosticsPanel';
 import ClarifyingQuestions from './ClarifyingQuestions';
 import PreviewTable from './PreviewTable';
 import { Download, FileIcon } from '../icons/Icons';
@@ -296,6 +297,7 @@ export default function AssistantMessage({
                         )}
                       </div>
                       <ValidationReport report={report} />
+                      <DiagnosticsPanel diagnostics={genResult?.diagnostics} />
                     </>
                   )}
                 </div>

--- a/frontend/src/components/workspace/DiagnosticsPanel.tsx
+++ b/frontend/src/components/workspace/DiagnosticsPanel.tsx
@@ -1,0 +1,271 @@
+import { useEffect, useState } from 'react';
+import type {
+  DiagnosticsReport,
+  ConfusionMatrix,
+  FeatureAblationEntry,
+} from '../../api/client';
+
+interface Props {
+  diagnostics: DiagnosticsReport | null | undefined;
+}
+
+type Tone = 'pass' | 'warn' | 'fail' | 'info';
+
+function pct(n: number, total: number): string {
+  if (total <= 0) return '—';
+  return `${Math.round((n / total) * 1000) / 10}%`;
+}
+
+function interpretationTone(interpretation: FeatureAblationEntry['interpretation']): Tone {
+  if (interpretation === 'high reliance') return 'pass';
+  if (interpretation === 'useful') return 'warn';
+  if (interpretation === 'marginal') return 'info';
+  return 'fail'; // harmful when present
+}
+
+function ConfusionGrid({
+  label,
+  abbrev,
+  matrix,
+}: {
+  label: string;
+  abbrev: string;
+  matrix: ConfusionMatrix;
+}) {
+  const total = matrix.tn + matrix.fp + matrix.fn + matrix.tp;
+  return (
+    <div className="dp-conf-matrix">
+      <div className="dp-conf-label">
+        {label} <span className="dp-muted">({abbrev})</span>
+      </div>
+      <table className="dp-conf-grid">
+        <thead>
+          <tr>
+            <th></th>
+            <th className="dp-conf-head">Pred 0</th>
+            <th className="dp-conf-head">Pred 1</th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr>
+            <th className="dp-conf-head">True 0</th>
+            <td className="dp-conf-cell dp-conf-correct">
+              <div className="dp-conf-n">{matrix.tn.toLocaleString()}</div>
+              <div className="dp-conf-pct">{pct(matrix.tn, total)}</div>
+              <div className="dp-conf-tag">TN</div>
+            </td>
+            <td className="dp-conf-cell dp-conf-fp">
+              <div className="dp-conf-n">{matrix.fp.toLocaleString()}</div>
+              <div className="dp-conf-pct">{pct(matrix.fp, total)}</div>
+              <div className="dp-conf-tag">FP</div>
+            </td>
+          </tr>
+          <tr>
+            <th className="dp-conf-head">True 1</th>
+            <td className="dp-conf-cell dp-conf-fn">
+              <div className="dp-conf-n">{matrix.fn.toLocaleString()}</div>
+              <div className="dp-conf-pct">{pct(matrix.fn, total)}</div>
+              <div className="dp-conf-tag">FN</div>
+            </td>
+            <td className="dp-conf-cell dp-conf-correct">
+              <div className="dp-conf-n">{matrix.tp.toLocaleString()}</div>
+              <div className="dp-conf-pct">{pct(matrix.tp, total)}</div>
+              <div className="dp-conf-tag">TP</div>
+            </td>
+          </tr>
+        </tbody>
+      </table>
+    </div>
+  );
+}
+
+function AblationBars({
+  ablation,
+  animated,
+}: {
+  ablation: FeatureAblationEntry[];
+  animated: boolean;
+}) {
+  const maxAbs = Math.max(1, ...ablation.map((a) => Math.abs(a.recall_delta_pct)));
+  return (
+    <div className="dp-abl-list">
+      {ablation.map((a) => {
+        const tone = interpretationTone(a.interpretation);
+        const width = Math.min(100, (Math.abs(a.recall_delta_pct) / maxAbs) * 100);
+        const sign = a.recall_delta_pct >= 0 ? '+' : '';
+        return (
+          <div key={a.feature} className="dp-abl-row">
+            <div className="dp-abl-name dp-mono" title={a.feature}>
+              {a.feature}
+            </div>
+            <div className="dp-abl-bar-track">
+              <div
+                className={`dp-abl-bar dp-bar-${tone}`}
+                style={{ width: animated ? `${width}%` : '0%' }}
+              />
+            </div>
+            <div className="dp-abl-delta dp-mono">
+              {sign}
+              {a.recall_delta_pct}pt
+            </div>
+            <div className="dp-abl-tag dp-muted">{a.interpretation}</div>
+          </div>
+        );
+      })}
+    </div>
+  );
+}
+
+function MisclassCards({
+  overlap,
+}: {
+  overlap: NonNullable<DiagnosticsReport['misclassification_overlap']>;
+}) {
+  const c = overlap.counts;
+  const buckets: Array<{ name: string; count: number; tone: Tone; desc: string }> = [
+    {
+      name: 'Synthetic helps',
+      count: c.trtr_only_wrong,
+      tone: 'pass',
+      desc: 'Real-only got these wrong; synthetic-only got them right',
+    },
+    {
+      name: 'Synthetic hurts',
+      count: c.tstr_only_wrong,
+      tone: 'fail',
+      desc: 'Real-only got these right; synthetic-only got them wrong',
+    },
+    {
+      name: 'Both wrong',
+      count: c.both_wrong,
+      tone: 'warn',
+      desc: 'Genuinely hard rows neither regime classifies correctly',
+    },
+    {
+      name: 'Augmentation saves',
+      count: c.augmentation_saves,
+      tone: 'pass',
+      desc: 'Augmented model correct where at least one base regime failed',
+    },
+  ];
+
+  return (
+    <div className="dp-mc-grid">
+      {buckets.map((b) => (
+        <div key={b.name} className={`dp-mc-card dp-mc-card-${b.tone}`}>
+          <div className="dp-mc-name">{b.name}</div>
+          <div className="dp-mc-count">{b.count.toLocaleString()}</div>
+          <div className="dp-mc-desc dp-muted">{b.desc}</div>
+        </div>
+      ))}
+    </div>
+  );
+}
+
+export default function DiagnosticsPanel({ diagnostics }: Props) {
+  const [expanded, setExpanded] = useState(true);
+  const [animated, setAnimated] = useState(false);
+
+  useEffect(() => {
+    const t = window.setTimeout(() => setAnimated(true), 60);
+    return () => window.clearTimeout(t);
+  }, []);
+
+  if (!diagnostics || !diagnostics.available) {
+    return (
+      <div className="dp-card">
+        <div className="dp-header">
+          <span className="dp-title">Experiment Diagnostics</span>
+          <span className="dp-badge dp-badge-info">Unavailable</span>
+        </div>
+        <div className="dp-empty">
+          Requires a real source dataset with a label column. Upload data via the integrations
+          panel and re-generate to enable confusion matrices, feature ablation, and row-level
+          misclassification overlap.
+        </div>
+      </div>
+    );
+  }
+
+  const target = diagnostics.target ?? '?';
+  const nTest = diagnostics.n_test ?? 0;
+  const conf = diagnostics.confusion_matrices;
+  const ablation = diagnostics.feature_ablation ?? [];
+  const overlap = diagnostics.misclassification_overlap;
+  const observations = diagnostics.observations ?? [];
+  const recommendations = diagnostics.recommendations ?? [];
+
+  return (
+    <div className="dp-card">
+      <button
+        type="button"
+        className="dp-header dp-header-button"
+        onClick={() => setExpanded((e) => !e)}
+        aria-expanded={expanded}
+      >
+        <span className="dp-title">Experiment Diagnostics</span>
+        <span className="dp-meta">
+          Target: <span className="dp-mono">{target}</span> · {nTest.toLocaleString()} held-out
+          test rows
+        </span>
+        <span className={`dp-chevron${expanded ? ' dp-chevron-open' : ''}`}>▾</span>
+      </button>
+
+      {expanded && (
+        <div className="dp-body">
+          {conf && (
+            <div className="dp-section">
+              <div className="dp-section-label">Confusion Matrices</div>
+              <div className="dp-conf-matrices">
+                <ConfusionGrid label="Real only" abbrev="TRTR" matrix={conf.trtr} />
+                <ConfusionGrid label="Synthetic only" abbrev="TSTR" matrix={conf.tstr} />
+                <ConfusionGrid label="Real + Synthetic" abbrev="TR+STR" matrix={conf.augmented} />
+              </div>
+            </div>
+          )}
+
+          {ablation.length > 0 && (
+            <div className="dp-section">
+              <div className="dp-section-label">Feature Ablation (Augmented Model)</div>
+              <div className="dp-section-hint">
+                Recall drop when each top-importance feature is permuted in the test set. Larger
+                drops = model relies on that feature.
+              </div>
+              <AblationBars ablation={ablation} animated={animated} />
+            </div>
+          )}
+
+          {overlap && overlap.counts && (
+            <div className="dp-section">
+              <div className="dp-section-label">Row-Level Misclassification Overlap</div>
+              <div className="dp-section-hint">{overlap.summary}</div>
+              <MisclassCards overlap={overlap} />
+            </div>
+          )}
+
+          {observations.length > 0 && (
+            <div className="dp-section">
+              <div className="dp-section-label">Observations</div>
+              <ul className="dp-list">
+                {observations.map((o, i) => (
+                  <li key={i}>{o}</li>
+                ))}
+              </ul>
+            </div>
+          )}
+
+          {recommendations.length > 0 && (
+            <div className="dp-section">
+              <div className="dp-section-label">Recommendations</div>
+              <ol className="dp-list-num">
+                {recommendations.map((r, i) => (
+                  <li key={i}>{r}</li>
+                ))}
+              </ol>
+            </div>
+          )}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/frontend/src/styles/workspace.css
+++ b/frontend/src/styles/workspace.css
@@ -1632,3 +1632,269 @@
 .schema-progress.phase-done .schema-progress-bar-fill {
   background: rgba(120, 200, 120, 0.7);
 }
+
+/* ── Diagnostics Panel ─────────────────────────────────────────────── */
+
+.dp-card {
+  margin-top: 16px;
+  background: var(--surface);
+  border: 1px solid var(--border);
+  border-radius: 12px;
+  overflow: hidden;
+}
+
+.dp-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+  padding: 14px 18px;
+  border-bottom: 1px solid var(--border);
+}
+
+.dp-header-button {
+  width: 100%;
+  background: none;
+  border: none;
+  color: inherit;
+  cursor: pointer;
+  font: inherit;
+  text-align: left;
+}
+
+.dp-header-button:hover { background: rgba(255, 255, 255, 0.02); }
+
+.dp-title {
+  font-size: 13px;
+  font-weight: 500;
+  color: var(--text);
+  letter-spacing: 0.02em;
+}
+
+.dp-meta {
+  font-size: 11px;
+  color: var(--text-muted);
+  font-family: var(--mono);
+}
+
+.dp-chevron {
+  font-size: 12px;
+  color: var(--text-dim);
+  transition: transform 0.2s ease;
+}
+
+.dp-chevron-open { transform: rotate(180deg); }
+
+.dp-badge {
+  display: inline-block;
+  padding: 2px 8px;
+  border-radius: 10px;
+  font-size: 10px;
+  letter-spacing: 0.06em;
+  font-weight: 500;
+}
+
+.dp-badge-info {
+  background: rgba(107, 122, 143, 0.16);
+  color: #9aa6b8;
+}
+
+.dp-empty {
+  padding: 18px;
+  font-size: 12px;
+  color: var(--text-muted);
+  line-height: 1.5;
+}
+
+.dp-body {
+  padding: 14px 18px 18px;
+  display: flex;
+  flex-direction: column;
+  gap: 18px;
+}
+
+.dp-section {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.dp-section-label {
+  font-size: 11px;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: var(--text-muted);
+  font-weight: 500;
+}
+
+.dp-section-hint {
+  font-size: 11px;
+  color: var(--text-muted);
+  line-height: 1.5;
+}
+
+.dp-mono { font-family: var(--mono); }
+.dp-muted { color: var(--text-muted); font-size: 12px; }
+
+/* Confusion matrices */
+.dp-conf-matrices {
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  gap: 12px;
+}
+
+.dp-conf-matrix {
+  background: var(--bg);
+  border: 1px solid var(--border);
+  border-radius: 8px;
+  padding: 10px;
+  text-align: center;
+}
+
+.dp-conf-label {
+  font-size: 10px;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+  color: var(--text-muted);
+  margin-bottom: 8px;
+  font-weight: 500;
+}
+
+.dp-conf-grid {
+  width: 100%;
+  border-collapse: collapse;
+  font-size: 11px;
+}
+
+.dp-conf-grid th {
+  color: var(--text-dim);
+  font-weight: 500;
+  padding: 3px;
+  font-family: var(--mono);
+  border: none;
+  background: none;
+}
+
+.dp-conf-head {
+  font-size: 9px !important;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+}
+
+.dp-conf-cell {
+  padding: 8px 4px;
+  border: 1px solid var(--border);
+  font-family: var(--mono);
+  position: relative;
+}
+
+.dp-conf-correct { background: rgba(122, 154, 109, 0.12); }
+.dp-conf-fp { background: rgba(200, 155, 60, 0.14); }
+.dp-conf-fn { background: rgba(192, 82, 74, 0.14); }
+
+.dp-conf-n { font-size: 14px; color: var(--text); }
+.dp-conf-pct { font-size: 9px; color: var(--text-muted); margin-top: 1px; }
+
+.dp-conf-tag {
+  position: absolute;
+  top: 2px;
+  right: 4px;
+  font-size: 8px;
+  color: var(--text-dim);
+  letter-spacing: 0.05em;
+}
+
+/* Feature ablation bars */
+.dp-abl-list {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+
+.dp-abl-row {
+  display: grid;
+  grid-template-columns: 140px 1fr 60px 110px;
+  align-items: center;
+  gap: 10px;
+  font-size: 12px;
+}
+
+.dp-abl-name {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  color: var(--text);
+}
+
+.dp-abl-bar-track {
+  height: 7px;
+  background: var(--bg);
+  border-radius: 4px;
+  overflow: hidden;
+}
+
+.dp-abl-bar {
+  height: 100%;
+  border-radius: 4px;
+  transition: width 0.6s ease;
+}
+
+.dp-bar-pass { background: #7a9a6d; }
+.dp-bar-warn { background: #c89b3c; }
+.dp-bar-info { background: #6b7a8f; }
+.dp-bar-fail { background: #c0524a; }
+
+.dp-abl-delta { text-align: right; font-size: 12px; }
+.dp-abl-tag { font-size: 11px; }
+
+/* Misclassification overlap cards */
+.dp-mc-grid {
+  display: grid;
+  grid-template-columns: repeat(4, 1fr);
+  gap: 10px;
+}
+
+.dp-mc-card {
+  background: var(--bg);
+  border: 1px solid var(--border);
+  border-left: 3px solid var(--border);
+  padding: 12px;
+  border-radius: 6px;
+}
+
+.dp-mc-card-pass { border-left-color: #7a9a6d; }
+.dp-mc-card-warn { border-left-color: #c89b3c; }
+.dp-mc-card-fail { border-left-color: #c0524a; }
+
+.dp-mc-name {
+  font-size: 10px;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: var(--text-muted);
+  font-weight: 500;
+}
+
+.dp-mc-count {
+  font-family: var(--mono);
+  font-size: 20px;
+  margin: 6px 0 4px;
+  color: var(--text);
+}
+
+.dp-mc-desc {
+  font-size: 11px;
+  line-height: 1.4;
+}
+
+/* Lists */
+.dp-list, .dp-list-num {
+  margin: 0;
+  padding-left: 20px;
+  font-size: 13px;
+  color: var(--text);
+}
+
+.dp-list li, .dp-list-num li {
+  margin-bottom: 6px;
+  line-height: 1.5;
+}


### PR DESCRIPTION
Mirrors the Trust Report's Experiment Diagnostics section as a live panel in the workspace, so users see confusion matrices, feature ablation, and misclassification overlap without having to open the printable report.

New types in client.ts: ConfusionMatrix, FeatureAblationEntry, MisclassificationOverlap, DiagnosticsReport. DiagnosticsReport hangs off the top-level GenerateResponse.

The panel is collapsible, mirrors the Trust Report's visual language (color-coded cells, ablation bars, four-card overlap grid), and renders a single 'Unavailable' message when diagnostics weren't computed (no real source data or no label column).

Completes the four-phase Experiment Diagnostics arc (PRD P1 #8). Stacks on feat/diagnostics-phase-3.