### PR TITLE
Layer Claude domain enrichment on edge-case discovery :D

### DIFF
--- a/backend/services/edge_case_discovery.py
+++ b/backend/services/edge_case_discovery.py
@@ -5,15 +5,24 @@ Each suggestion's `condition_text` is in the same NL format `services/edge_cases
 already parses, so the approval flow can simply append accepted suggestions to the
 prompt's `edge_cases` array and the existing enforcer handles the rest.
 
-Phase 1 scope: four pure-statistical detectors over `source_stats` (and optionally a
-real DataFrame for conjunction detection). LLM enrichment lands in Phase 2.
+Two layers:
+  1. Pure-statistical detectors over `source_stats` (and optionally a real DataFrame
+     for conjunction detection). Always run.
+  2. Claude domain-enrichment that proposes additional patterns statistical detectors
+     can't see — column interactions, regulatory edge cases, business-critical rare
+     scenarios. Gated on ANTHROPIC_API_KEY; falls back silently if the key is missing
+     or the call fails.
 """
 from __future__ import annotations
 
+import json
+import re
 from dataclasses import dataclass, asdict
 from typing import Any, Literal
 
 import pandas as pd
+
+from core.config import llm
 
 Severity = Literal["low", "medium", "high"]
 
@@ -41,7 +50,7 @@ NULL_LIKE_TOKENS = {"?", "", "none", "nan", "n/a", "na", "unknown", "null"}
 class EdgeCaseSuggestion:
     description: str                # human-readable summary
     condition_text: str             # NL-edge-case format — feeds parse_edge_case()
-    source_pct: float               # % of source data matching this pattern
+    source_pct: float | None        # % of source matching; None when LLM proposes without data measurement
     suggested_target_pct: float     # recommended target_fraction (as %)
     reason: str                     # one-sentence rationale
     severity: Severity
@@ -273,11 +282,18 @@ def _detect_sparse_conjunctions(
 _SEVERITY_RANK = {"high": 0, "medium": 1, "low": 2}
 
 
+def _sort_key(s: EdgeCaseSuggestion) -> tuple[int, float]:
+    # None source_pct (LLM-only) sorts last within its severity bucket — surface measurable
+    # statistical findings ahead of unverified domain hunches.
+    pct = s.source_pct if s.source_pct is not None else float("inf")
+    return (_SEVERITY_RANK[s.severity], pct)
+
+
 def _rank_and_dedupe(suggestions: list[EdgeCaseSuggestion]) -> list[EdgeCaseSuggestion]:
     """Order by severity then rarity; dedupe identical condition_text; cap total."""
     seen: set[str] = set()
     deduped: list[EdgeCaseSuggestion] = []
-    ordered = sorted(suggestions, key=lambda s: (_SEVERITY_RANK[s.severity], s.source_pct))
+    ordered = sorted(suggestions, key=_sort_key)
     for s in ordered:
         if s.condition_text in seen:
             continue
@@ -288,19 +304,207 @@ def _rank_and_dedupe(suggestions: list[EdgeCaseSuggestion]) -> list[EdgeCaseSugg
     return deduped
 
 
+# ── LLM enrichment (Phase 2) ──────────────────────────────────────────────────
+
+_LLM_MODEL = "claude-sonnet-4-6"
+_LLM_MAX_TOKENS = 1500
+_LLM_MAX_NEW_SUGGESTIONS = 5
+
+_LLM_SYSTEM_PROMPT = """\
+You are a domain expert in synthetic data generation and edge-case design for ML training datasets. \
+Given a tabular schema, a statistical summary of source data, and a list of statistical edge-case \
+suggestions that have already been identified, propose ADDITIONAL domain-important edge-case \
+patterns that pure statistical detectors cannot see.
+
+Focus on:
+- Meaningful interactions between two or more columns (e.g. high premium AND low tenure)
+- Regulatory / compliance edge cases relevant to the inferred domain
+- Rare-but-business-critical scenarios that an expert in the field would test for
+- Patterns where naive synthesis is known to fail
+
+DO NOT repeat the statistical suggestions provided. DO NOT propose patterns that require columns \
+outside the provided schema. Each `condition_text` must use the exact column names from the schema, \
+with comparison operators (`>`, `<`, `>=`, `<=`, `==`, `!=`) or the form `N+ column` for `column >= N`. \
+Connect multiple conditions with the word `and`. Optionally prefix with `N% of` to suggest a target \
+fraction (defaults to 5% if omitted).
+
+Respond ONLY with a valid JSON array (no markdown fences, no prose). Each element must have:
+  description        – short human-readable summary (~10 words)
+  condition_text     – NL condition in the format above
+  suggested_target_pct – integer or float between 1 and 30
+  reason             – one-sentence rationale (~25 words, cite domain knowledge)
+  severity           – one of: "high", "medium", "low"
+
+Return 1–5 suggestions. Quality over quantity. Skip if no defensible domain edge cases exist beyond \
+what the statistical detectors already found."""
+
+
+def _infer_domain_hint(schema_columns: list[dict]) -> str:
+    """Cheap keyword-based domain hint so Claude's reasoning is grounded."""
+    names = " ".join(c.get("column", "").lower() for c in schema_columns)
+    if any(k in names for k in ("claim", "policy", "premium", "umbrella", "incident_type", "collision")):
+        return "auto / property insurance claims"
+    if any(k in names for k in ("patient", "hba1c", "diagnosis", "icd", "ehr")):
+        return "clinical / EHR records"
+    if any(k in names for k in ("loan", "credit", "fraud", "transaction", "merchant")):
+        return "financial transactions"
+    if any(k in names for k in ("order", "product", "cart", "purchase")):
+        return "e-commerce orders"
+    return "(domain inferred from column names)"
+
+
+def _schema_for_prompt(schema_columns: list[dict]) -> str:
+    lines = []
+    for c in schema_columns[:40]:  # cap to keep tokens bounded
+        col = c.get("column", "?")
+        col_type = c.get("type", "?")
+        dist = c.get("distribution", "")
+        line = f"- {col} ({col_type})"
+        if dist:
+            line += f" — {dist}"
+        lines.append(line)
+    return "\n".join(lines)
+
+
+def _stats_summary_for_prompt(source_stats: dict[str, dict]) -> str:
+    parts = []
+    for col, stat in list(source_stats.items())[:30]:
+        if not isinstance(stat, dict):
+            continue
+        ct = stat.get("col_type")
+        if ct in ("int", "float"):
+            parts.append(
+                f"- {col} ({ct}): mean={stat.get('mean'):.2f}, std={stat.get('std'):.2f}, "
+                f"min={stat.get('min')}, max={stat.get('max')}, skew={stat.get('skew', 0):.2f}"
+            )
+        elif ct == "enum":
+            cats = stat.get("categories", [])[:6]
+            probs = stat.get("probs", [])[:6]
+            cat_str = ", ".join(f"{c}={p*100:.1f}%" for c, p in zip(cats, probs))
+            parts.append(f"- {col} (enum): {cat_str}")
+        elif ct == "bool":
+            parts.append(f"- {col} (bool): p_true={stat.get('p_true', 0):.3f}")
+        elif ct == "date":
+            parts.append(f"- {col} (date): range {stat.get('min_ts')} → {stat.get('max_ts')}")
+    return "\n".join(parts)
+
+
+def _strip_code_fences(text: str) -> str:
+    text = re.sub(r"^```(?:json)?\s*", "", text.strip())
+    text = re.sub(r"\s*```$", "", text)
+    return text.strip()
+
+
+def _validate_llm_suggestion(raw: dict, schema_column_names: set[str]) -> EdgeCaseSuggestion | None:
+    """Defensively coerce one LLM-returned dict into an EdgeCaseSuggestion, or drop it."""
+    try:
+        description = str(raw.get("description", "")).strip()
+        condition_text = str(raw.get("condition_text", "")).strip()
+        reason = str(raw.get("reason", "")).strip()
+        severity = str(raw.get("severity", "medium")).lower().strip()
+        target = float(raw.get("suggested_target_pct", 5.0))
+    except (TypeError, ValueError):
+        return None
+
+    if not description or not condition_text or not reason:
+        return None
+    if severity not in _SEVERITY_RANK:
+        severity = "medium"
+    target = max(MIN_SUGGESTED_TARGET_PCT, min(MAX_SUGGESTED_TARGET_PCT, target))
+
+    # Sanity check: at least one schema column should appear in the condition.
+    if not any(col in condition_text for col in schema_column_names):
+        return None
+
+    return EdgeCaseSuggestion(
+        description=description,
+        condition_text=condition_text,
+        source_pct=None,  # LLM didn't measure against data
+        suggested_target_pct=round(target, 1),
+        reason=reason,
+        severity=severity,  # type: ignore[arg-type]
+        detector="domain_llm",
+    )
+
+
+def _enrich_with_claude(
+    schema_columns: list[dict],
+    source_stats: dict[str, dict],
+    statistical: list[EdgeCaseSuggestion],
+) -> list[EdgeCaseSuggestion]:
+    """Ask Claude for additional domain-specific edge cases beyond what statistics caught.
+
+    Returns an empty list silently if the LLM is unavailable or the call fails. Phase 1's
+    statistical suggestions remain authoritative; LLM suggestions are layered on top.
+    """
+    if llm is None:
+        return []
+    if not schema_columns:
+        return []
+
+    domain = _infer_domain_hint(schema_columns)
+    existing = "\n".join(f"- {s.condition_text}" for s in statistical[:8]) or "(none)"
+    user_prompt = (
+        f"Domain (best guess from column names): {domain}\n\n"
+        f"Schema:\n{_schema_for_prompt(schema_columns)}\n\n"
+        f"Source-data statistical summary:\n{_stats_summary_for_prompt(source_stats)}\n\n"
+        f"Statistical detectors already proposed these edge cases — DO NOT duplicate:\n{existing}\n\n"
+        f"Return JSON only."
+    )
+
+    try:
+        msg = llm.messages.create(
+            model=_LLM_MODEL,
+            max_tokens=_LLM_MAX_TOKENS,
+            system=_LLM_SYSTEM_PROMPT,
+            messages=[{"role": "user", "content": user_prompt}],
+        )
+        raw_text = msg.content[0].text
+    except Exception:
+        return []
+
+    cleaned = _strip_code_fences(raw_text)
+    try:
+        items = json.loads(cleaned)
+    except json.JSONDecodeError:
+        return []
+    if not isinstance(items, list):
+        return []
+
+    schema_column_names = {c.get("column", "") for c in schema_columns if c.get("column")}
+    enriched: list[EdgeCaseSuggestion] = []
+    for raw in items[:_LLM_MAX_NEW_SUGGESTIONS]:
+        if not isinstance(raw, dict):
+            continue
+        s = _validate_llm_suggestion(raw, schema_column_names)
+        if s is not None:
+            enriched.append(s)
+    return enriched
+
+
 def discover_edge_cases(
     schema_columns: list[dict],
     source_stats: dict[str, dict],
     real_df: pd.DataFrame | None = None,
+    enrich_with_llm: bool = True,
 ) -> list[EdgeCaseSuggestion]:
-    """Run all statistical detectors over the source profile and return a ranked suggestion list."""
-    raw: list[EdgeCaseSuggestion] = []
+    """Run statistical detectors, then (optionally) layer Claude domain-enrichment on top.
+
+    Returns a ranked, deduped suggestion list. LLM enrichment is silent-fallback: if the
+    API key is missing or the call fails, the statistical suggestions still ship.
+    """
+    statistical: list[EdgeCaseSuggestion] = []
     for col_name, stat in (source_stats or {}).items():
         if not isinstance(stat, dict):
             continue
-        raw.extend(_detect_sparse_categorical(col_name, stat))
-        raw.extend(_detect_tail_outliers(col_name, stat))
-        raw.extend(_detect_class_imbalance(col_name, stat))
+        statistical.extend(_detect_sparse_categorical(col_name, stat))
+        statistical.extend(_detect_tail_outliers(col_name, stat))
+        statistical.extend(_detect_class_imbalance(col_name, stat))
 
-    raw.extend(_detect_sparse_conjunctions(real_df, schema_columns))
-    return _rank_and_dedupe(raw)
+    statistical.extend(_detect_sparse_conjunctions(real_df, schema_columns))
+
+    llm_suggestions: list[EdgeCaseSuggestion] = []
+    if enrich_with_llm:
+        llm_suggestions = _enrich_with_claude(schema_columns, source_stats, statistical)
+
+    return _rank_and_dedupe(statistical + llm_suggestions)

--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -168,6 +168,7 @@ export async function previewDataset(
   schemaColumns: SchemaColumn[],
   sourceStats: SourceStats,
   modelId?: string | null,
+  edgeCases: string[] = [],
 ): Promise<{ rows: Record<string, unknown>[] }> {
   const res = await fetch(`${BASE}/preview`, {
     method: 'POST',
@@ -178,6 +179,7 @@ export async function previewDataset(
       row_count: 10,
       prompt: '',
       model_id: modelId ?? null,
+      edge_cases: edgeCases,
     }),
   });
   if (!res.ok) throw new Error(`Preview failed: ${res.statusText}`);
@@ -218,6 +220,42 @@ export function downloadUrl(sessionId: string): string {
 
 export function reportUrl(sessionId: string): string {
   return `${BASE}/report/${sessionId}`;
+}
+
+// ── Edge-case discovery ──────────────────────────────────────────────────
+
+export type EdgeCaseSeverity = 'high' | 'medium' | 'low';
+
+export interface EdgeCaseSuggestion {
+  description: string;
+  condition_text: string;
+  source_pct: number | null;
+  suggested_target_pct: number;
+  reason: string;
+  severity: EdgeCaseSeverity;
+  detector: string;
+}
+
+export interface DiscoverEdgeCasesResponse {
+  suggestions: EdgeCaseSuggestion[];
+}
+
+export async function discoverEdgeCases(
+  schemaColumns: SchemaColumn[],
+  sourceStats: SourceStats,
+  sourceId?: string | null,
+): Promise<DiscoverEdgeCasesResponse> {
+  const res = await fetch(`${BASE}/discover-edge-cases`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({
+      schema_columns: schemaColumns,
+      source_stats: sourceStats,
+      source_id: sourceId ?? null,
+    }),
+  });
+  if (!res.ok) throw new Error(`Edge-case discovery failed: ${res.statusText}`);
+  return res.json();
 }
 
 export interface MongoTestResponse {

--- a/frontend/src/components/workspace/AssistantMessage.tsx
+++ b/frontend/src/components/workspace/AssistantMessage.tsx
@@ -7,6 +7,7 @@ import SchemaCard from './SchemaCard';
 import SchemaInferenceProgress from './SchemaInferenceProgress';
 import ValidationReport from './ValidationReport';
 import DiagnosticsPanel from './DiagnosticsPanel';
+import EdgeCaseSuggestions from './EdgeCaseSuggestions';
 import ClarifyingQuestions from './ClarifyingQuestions';
 import PreviewTable from './PreviewTable';
 import { Download, FileIcon } from '../icons/Icons';
@@ -57,6 +58,9 @@ export default function AssistantMessage({
 
   const [clarifyDismissed, setClarifyDismissed] = useState(false);
 
+  // Approved edge-case discovery suggestions, merged into edge_cases on preview + generate.
+  const [approvedSuggestions, setApprovedSuggestions] = useState<string[]>([]);
+
   const hasClarifying = (clarifyingQuestions?.length ?? 0) > 0 && !clarifyDismissed;
 
   // Sync the legacy 3-step agent panel with real user-driven actions:
@@ -78,6 +82,12 @@ export default function AssistantMessage({
     });
   }, [agents, approval, previewLoading]);
 
+  const mergedEdgeCases = () => {
+    const base = generationSpec?.edge_cases ?? [];
+    const seen = new Set(base);
+    return [...base, ...approvedSuggestions.filter((c) => !seen.has(c))];
+  };
+
   const handlePreview = async () => {
     if (!schema || schema.length === 0) return;
     setPreviewLoading(true);
@@ -87,6 +97,7 @@ export default function AssistantMessage({
         schema,
         (sourceStats as SourceStats) ?? {},
         modelId,
+        mergedEdgeCases(),
       );
       setPreviewRows(result.rows);
     } catch (err) {
@@ -107,7 +118,7 @@ export default function AssistantMessage({
         rowCount,
         originalPrompt ?? '',
         format,
-        generationSpec?.edge_cases ?? [],
+        mergedEdgeCases(),
         modelId,
         sourceId,
       );
@@ -175,6 +186,16 @@ export default function AssistantMessage({
             {schema && (
               <>
                 <SchemaCard rows={schema} source={schemaSource} />
+
+                {sourceStats && Object.keys(sourceStats).length > 0 && (
+                  <EdgeCaseSuggestions
+                    schemaColumns={schema}
+                    sourceStats={sourceStats as SourceStats}
+                    sourceId={sourceId}
+                    approvedConditions={approvedSuggestions}
+                    onApprovedChange={setApprovedSuggestions}
+                  />
+                )}
 
                 {hasClarifying && clarifyingQuestions && (
                   <ClarifyingQuestions

--- a/frontend/src/components/workspace/EdgeCaseSuggestions.tsx
+++ b/frontend/src/components/workspace/EdgeCaseSuggestions.tsx
@@ -1,0 +1,184 @@
+import { useEffect, useState } from 'react';
+import { Check, Plus } from '../icons/Icons';
+import {
+  discoverEdgeCases,
+  type EdgeCaseSeverity,
+  type EdgeCaseSuggestion,
+  type SchemaColumn,
+  type SourceStats,
+} from '../../api/client';
+
+interface Props {
+  schemaColumns: SchemaColumn[];
+  sourceStats: SourceStats;
+  sourceId?: string | null;
+  approvedConditions: string[];
+  onApprovedChange: (next: string[]) => void;
+}
+
+type Status = 'idle' | 'loading' | 'ready' | 'empty' | 'error';
+
+function pctText(pct: number | null): string {
+  if (pct === null) return '—';
+  if (pct < 0.1) return `${pct.toFixed(2)}%`;
+  return `${pct.toFixed(1)}%`;
+}
+
+function severityLabel(s: EdgeCaseSeverity): string {
+  return s === 'high' ? 'High priority' : s === 'medium' ? 'Medium' : 'Low';
+}
+
+function detectorLabel(d: string): string {
+  if (d === 'sparse_categorical') return 'Rare category';
+  if (d === 'tail_outlier') return 'Distribution tail';
+  if (d === 'class_imbalance') return 'Class imbalance';
+  if (d === 'sparse_conjunction') return 'Rare combination';
+  if (d === 'domain_llm') return 'Domain expert';
+  return d;
+}
+
+export default function EdgeCaseSuggestions({
+  schemaColumns,
+  sourceStats,
+  sourceId,
+  approvedConditions,
+  onApprovedChange,
+}: Props) {
+  const [status, setStatus] = useState<Status>('idle');
+  const [suggestions, setSuggestions] = useState<EdgeCaseSuggestion[]>([]);
+  const [expandedIdx, setExpandedIdx] = useState<number | null>(null);
+  const [error, setError] = useState<string | null>(null);
+
+  // Fire discovery once we have schema + stats. Re-fires only if columns change.
+  const schemaKey = schemaColumns.map((c) => c.column).join('|');
+  const hasStats = Object.keys(sourceStats).length > 0;
+
+  useEffect(() => {
+    if (!schemaColumns.length || !hasStats) return;
+    let cancelled = false;
+    setStatus('loading');
+    setError(null);
+    discoverEdgeCases(schemaColumns, sourceStats, sourceId)
+      .then((resp) => {
+        if (cancelled) return;
+        if (!resp.suggestions || resp.suggestions.length === 0) {
+          setStatus('empty');
+          setSuggestions([]);
+          return;
+        }
+        setSuggestions(resp.suggestions);
+        setStatus('ready');
+      })
+      .catch((err) => {
+        if (cancelled) return;
+        setStatus('error');
+        setError(err instanceof Error ? err.message : 'Discovery failed');
+      });
+    return () => {
+      cancelled = true;
+    };
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [schemaKey, sourceId]);
+
+  if (status === 'idle' || status === 'empty') return null;
+
+  const approvedSet = new Set(approvedConditions);
+
+  const toggleApprove = (condition: string) => {
+    const next = approvedSet.has(condition)
+      ? approvedConditions.filter((c) => c !== condition)
+      : [...approvedConditions, condition];
+    onApprovedChange(next);
+  };
+
+  return (
+    <div className="ws-eds-card">
+      <div className="ws-eds-header">
+        <div className="ws-eds-title">Discovered Edge Cases</div>
+        <div className="ws-eds-subtitle">
+          {status === 'loading'
+            ? 'Scanning source data for under-represented patterns…'
+            : status === 'error'
+              ? error ?? 'Discovery failed'
+              : `${suggestions.length} pattern${suggestions.length === 1 ? '' : 's'} found · click to enforce`}
+        </div>
+      </div>
+
+      {status === 'loading' && (
+        <div className="ws-eds-loading">
+          <div className="ws-typing">
+            <span className="ws-typing-dot" />
+            <span className="ws-typing-dot" />
+            <span className="ws-typing-dot" />
+          </div>
+        </div>
+      )}
+
+      {status === 'error' && (
+        <div className="ws-eds-empty">
+          Edge-case discovery unavailable on this run. Generation will proceed without suggested
+          patterns.
+        </div>
+      )}
+
+      {status === 'ready' && (
+        <div className="ws-eds-list">
+          {suggestions.map((s, i) => {
+            const approved = approvedSet.has(s.condition_text);
+            const expanded = expandedIdx === i;
+            return (
+              <div
+                key={`${s.condition_text}-${i}`}
+                className={`ws-eds-chip ws-eds-chip-${s.severity}${
+                  approved ? ' ws-eds-chip-approved' : ''
+                }`}
+              >
+                <button
+                  type="button"
+                  className="ws-eds-chip-main"
+                  onClick={() => toggleApprove(s.condition_text)}
+                  aria-pressed={approved}
+                >
+                  <span className="ws-eds-chip-icon">
+                    {approved ? <Check size={11} strokeWidth={2.5} /> : <Plus size={11} strokeWidth={2.5} />}
+                  </span>
+                  <span className="ws-eds-chip-condition">{s.condition_text}</span>
+                  <span className="ws-eds-chip-meta">
+                    <span className="ws-eds-chip-source">source {pctText(s.source_pct)}</span>
+                    <span className="ws-eds-chip-sep">·</span>
+                    <span className={`ws-eds-chip-severity ws-eds-sev-${s.severity}`}>
+                      {severityLabel(s.severity)}
+                    </span>
+                  </span>
+                </button>
+                <button
+                  type="button"
+                  className="ws-eds-chip-why"
+                  onClick={() => setExpandedIdx(expanded ? null : i)}
+                  aria-expanded={expanded}
+                >
+                  {expanded ? 'Hide' : 'Why?'}
+                </button>
+                {expanded && (
+                  <div className="ws-eds-chip-reason">
+                    <div className="ws-eds-chip-reason-tag">
+                      {detectorLabel(s.detector)} · target {s.suggested_target_pct}%
+                    </div>
+                    <div>{s.reason}</div>
+                  </div>
+                )}
+              </div>
+            );
+          })}
+        </div>
+      )}
+
+      {status === 'ready' && approvedConditions.length > 0 && (
+        <div className="ws-eds-footer">
+          {approvedConditions.length} edge case{approvedConditions.length === 1 ? '' : 's'} approved
+          · will be enforced on next generation
+        </div>
+      )}
+    </div>
+  );
+}

--- a/frontend/src/styles/workspace.css
+++ b/frontend/src/styles/workspace.css
@@ -1922,3 +1922,192 @@
   margin-bottom: 6px;
   line-height: 1.5;
 }
+
+/* ── Edge-Case Discovery (chip strip) ─────────────────────────────────── */
+
+.ws-eds-card {
+  margin-top: 16px;
+  background: var(--surface);
+  border: 1px solid var(--border);
+  border-radius: 12px;
+  padding: 14px 18px;
+}
+
+.ws-eds-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: baseline;
+  gap: 12px;
+  margin-bottom: 12px;
+}
+
+.ws-eds-title {
+  font-size: 13px;
+  font-weight: 500;
+  color: var(--text);
+  letter-spacing: 0.02em;
+}
+
+.ws-eds-subtitle {
+  font-size: 11px;
+  color: var(--text-muted);
+}
+
+.ws-eds-loading {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 8px 0 14px;
+}
+
+.ws-eds-empty {
+  font-size: 12px;
+  color: var(--text-muted);
+  padding: 8px 0;
+}
+
+.ws-eds-list {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+
+.ws-eds-chip {
+  display: grid;
+  grid-template-columns: 1fr auto;
+  align-items: center;
+  gap: 8px;
+  background: var(--bg);
+  border: 1px solid var(--border);
+  border-left: 3px solid var(--border);
+  border-radius: 6px;
+  padding: 0;
+  transition: background 0.15s ease, border-color 0.15s ease;
+}
+
+.ws-eds-chip-high { border-left-color: #c0524a; }
+.ws-eds-chip-medium { border-left-color: #c89b3c; }
+.ws-eds-chip-low { border-left-color: #6b7a8f; }
+
+.ws-eds-chip:hover {
+  background: rgba(255, 255, 255, 0.02);
+}
+
+.ws-eds-chip-approved {
+  background: rgba(122, 154, 109, 0.08);
+  border-color: rgba(122, 154, 109, 0.4);
+}
+
+.ws-eds-chip-approved.ws-eds-chip-high { border-left-color: #7a9a6d; }
+.ws-eds-chip-approved.ws-eds-chip-medium { border-left-color: #7a9a6d; }
+.ws-eds-chip-approved.ws-eds-chip-low { border-left-color: #7a9a6d; }
+
+.ws-eds-chip-main {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  background: none;
+  border: none;
+  color: inherit;
+  cursor: pointer;
+  padding: 10px 14px;
+  font: inherit;
+  text-align: left;
+  min-width: 0;
+}
+
+.ws-eds-chip-icon {
+  width: 16px;
+  height: 16px;
+  border-radius: 50%;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  color: var(--text-muted);
+  flex-shrink: 0;
+}
+
+.ws-eds-chip-approved .ws-eds-chip-icon {
+  background: var(--accent);
+  color: white;
+}
+
+.ws-eds-chip-condition {
+  font-family: var(--mono);
+  font-size: 12px;
+  color: var(--text);
+  flex: 1;
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.ws-eds-chip-meta {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  font-size: 11px;
+  color: var(--text-muted);
+  flex-shrink: 0;
+}
+
+.ws-eds-chip-source {
+  font-family: var(--mono);
+}
+
+.ws-eds-chip-sep {
+  opacity: 0.5;
+}
+
+.ws-eds-chip-severity {
+  font-size: 10px;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+  font-weight: 500;
+}
+
+.ws-eds-sev-high { color: #d97c75; }
+.ws-eds-sev-medium { color: #d8b465; }
+.ws-eds-sev-low { color: #9aa6b8; }
+
+.ws-eds-chip-why {
+  background: none;
+  border: none;
+  color: var(--text-dim);
+  font-size: 11px;
+  padding: 0 14px;
+  cursor: pointer;
+  height: 100%;
+}
+
+.ws-eds-chip-why:hover {
+  color: var(--text);
+}
+
+.ws-eds-chip-reason {
+  grid-column: 1 / -1;
+  padding: 10px 16px 12px 40px;
+  font-size: 12px;
+  color: var(--text-muted);
+  border-top: 1px solid var(--border);
+  line-height: 1.5;
+}
+
+.ws-eds-chip-reason-tag {
+  font-size: 10px;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: var(--text-dim);
+  margin-bottom: 4px;
+  font-weight: 500;
+}
+
+.ws-eds-footer {
+  margin-top: 10px;
+  padding-top: 10px;
+  border-top: 1px solid var(--border);
+  font-size: 11px;
+  color: var(--accent);
+  letter-spacing: 0.02em;
+}


### PR DESCRIPTION
Phase 2 adds an LLM pass that proposes additional domain-specific edge cases the statistical detectors cannot see — column interactions, regulatory edge cases, business-critical rare scenarios.

Implementation:
- _enrich_with_claude sends Claude the schema, statistical summary, and existing suggestions; asks for 1–5 ADDITIONAL patterns in the same condition_text format. Domain hint inferred from column-name keywords so reasoning is grounded.
- _validate_llm_suggestion defensively coerces each returned dict: bogus columns rejected, target% clamped to [5, 30], invalid severities coerced to 'medium', missing required fields dropped.
- source_pct is None for LLM suggestions (Claude can't measure source). Sorted last within their severity bucket so measurable statistical findings surface first.
- Silent-fallback: no API key, network error, JSON parse failure, or malformed suggestions all return []. Statistical results always ship.

No API contract change — the existing POST /api/discover-edge-cases endpoint automatically picks up enrichment when ANTHROPIC_API_KEY is set.

Stacks on feat/edge-case-discovery-phase-1 !!