### PR TITLE
Adding workspace chip strip for edge-case discovery approval

### DIFF
--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -168,6 +168,7 @@ export async function previewDataset(
   schemaColumns: SchemaColumn[],
   sourceStats: SourceStats,
   modelId?: string | null,
+  edgeCases: string[] = [],
 ): Promise<{ rows: Record<string, unknown>[] }> {
   const res = await fetch(`${BASE}/preview`, {
     method: 'POST',
@@ -178,6 +179,7 @@ export async function previewDataset(
       row_count: 10,
       prompt: '',
       model_id: modelId ?? null,
+      edge_cases: edgeCases,
     }),
   });
   if (!res.ok) throw new Error(`Preview failed: ${res.statusText}`);
@@ -218,6 +220,42 @@ export function downloadUrl(sessionId: string): string {
 
 export function reportUrl(sessionId: string): string {
   return `${BASE}/report/${sessionId}`;
+}
+
+// ── Edge-case discovery ──────────────────────────────────────────────────
+
+export type EdgeCaseSeverity = 'high' | 'medium' | 'low';
+
+export interface EdgeCaseSuggestion {
+  description: string;
+  condition_text: string;
+  source_pct: number | null;
+  suggested_target_pct: number;
+  reason: string;
+  severity: EdgeCaseSeverity;
+  detector: string;
+}
+
+export interface DiscoverEdgeCasesResponse {
+  suggestions: EdgeCaseSuggestion[];
+}
+
+export async function discoverEdgeCases(
+  schemaColumns: SchemaColumn[],
+  sourceStats: SourceStats,
+  sourceId?: string | null,
+): Promise<DiscoverEdgeCasesResponse> {
+  const res = await fetch(`${BASE}/discover-edge-cases`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({
+      schema_columns: schemaColumns,
+      source_stats: sourceStats,
+      source_id: sourceId ?? null,
+    }),
+  });
+  if (!res.ok) throw new Error(`Edge-case discovery failed: ${res.statusText}`);
+  return res.json();
 }
 
 export interface MongoTestResponse {

--- a/frontend/src/components/workspace/AssistantMessage.tsx
+++ b/frontend/src/components/workspace/AssistantMessage.tsx
@@ -7,6 +7,7 @@ import SchemaCard from './SchemaCard';
 import SchemaInferenceProgress from './SchemaInferenceProgress';
 import ValidationReport from './ValidationReport';
 import DiagnosticsPanel from './DiagnosticsPanel';
+import EdgeCaseSuggestions from './EdgeCaseSuggestions';
 import ClarifyingQuestions from './ClarifyingQuestions';
 import PreviewTable from './PreviewTable';
 import { Download, FileIcon } from '../icons/Icons';
@@ -57,6 +58,9 @@ export default function AssistantMessage({
 
   const [clarifyDismissed, setClarifyDismissed] = useState(false);
 
+  // Approved edge-case discovery suggestions, merged into edge_cases on preview + generate.
+  const [approvedSuggestions, setApprovedSuggestions] = useState<string[]>([]);
+
   const hasClarifying = (clarifyingQuestions?.length ?? 0) > 0 && !clarifyDismissed;
 
   // Sync the legacy 3-step agent panel with real user-driven actions:
@@ -78,6 +82,12 @@ export default function AssistantMessage({
     });
   }, [agents, approval, previewLoading]);
 
+  const mergedEdgeCases = () => {
+    const base = generationSpec?.edge_cases ?? [];
+    const seen = new Set(base);
+    return [...base, ...approvedSuggestions.filter((c) => !seen.has(c))];
+  };
+
   const handlePreview = async () => {
     if (!schema || schema.length === 0) return;
     setPreviewLoading(true);
@@ -87,6 +97,7 @@ export default function AssistantMessage({
         schema,
         (sourceStats as SourceStats) ?? {},
         modelId,
+        mergedEdgeCases(),
       );
       setPreviewRows(result.rows);
     } catch (err) {
@@ -107,7 +118,7 @@ export default function AssistantMessage({
         rowCount,
         originalPrompt ?? '',
         format,
-        generationSpec?.edge_cases ?? [],
+        mergedEdgeCases(),
         modelId,
         sourceId,
       );
@@ -175,6 +186,16 @@ export default function AssistantMessage({
             {schema && (
               <>
                 <SchemaCard rows={schema} source={schemaSource} />
+
+                {sourceStats && Object.keys(sourceStats).length > 0 && (
+                  <EdgeCaseSuggestions
+                    schemaColumns={schema}
+                    sourceStats={sourceStats as SourceStats}
+                    sourceId={sourceId}
+                    approvedConditions={approvedSuggestions}
+                    onApprovedChange={setApprovedSuggestions}
+                  />
+                )}
 
                 {hasClarifying && clarifyingQuestions && (
                   <ClarifyingQuestions

--- a/frontend/src/components/workspace/EdgeCaseSuggestions.tsx
+++ b/frontend/src/components/workspace/EdgeCaseSuggestions.tsx
@@ -1,0 +1,184 @@
+import { useEffect, useState } from 'react';
+import { Check, Plus } from '../icons/Icons';
+import {
+  discoverEdgeCases,
+  type EdgeCaseSeverity,
+  type EdgeCaseSuggestion,
+  type SchemaColumn,
+  type SourceStats,
+} from '../../api/client';
+
+interface Props {
+  schemaColumns: SchemaColumn[];
+  sourceStats: SourceStats;
+  sourceId?: string | null;
+  approvedConditions: string[];
+  onApprovedChange: (next: string[]) => void;
+}
+
+type Status = 'idle' | 'loading' | 'ready' | 'empty' | 'error';
+
+function pctText(pct: number | null): string {
+  if (pct === null) return '—';
+  if (pct < 0.1) return `${pct.toFixed(2)}%`;
+  return `${pct.toFixed(1)}%`;
+}
+
+function severityLabel(s: EdgeCaseSeverity): string {
+  return s === 'high' ? 'High priority' : s === 'medium' ? 'Medium' : 'Low';
+}
+
+function detectorLabel(d: string): string {
+  if (d === 'sparse_categorical') return 'Rare category';
+  if (d === 'tail_outlier') return 'Distribution tail';
+  if (d === 'class_imbalance') return 'Class imbalance';
+  if (d === 'sparse_conjunction') return 'Rare combination';
+  if (d === 'domain_llm') return 'Domain expert';
+  return d;
+}
+
+export default function EdgeCaseSuggestions({
+  schemaColumns,
+  sourceStats,
+  sourceId,
+  approvedConditions,
+  onApprovedChange,
+}: Props) {
+  const [status, setStatus] = useState<Status>('idle');
+  const [suggestions, setSuggestions] = useState<EdgeCaseSuggestion[]>([]);
+  const [expandedIdx, setExpandedIdx] = useState<number | null>(null);
+  const [error, setError] = useState<string | null>(null);
+
+  // Fire discovery once we have schema + stats. Re-fires only if columns change.
+  const schemaKey = schemaColumns.map((c) => c.column).join('|');
+  const hasStats = Object.keys(sourceStats).length > 0;
+
+  useEffect(() => {
+    if (!schemaColumns.length || !hasStats) return;
+    let cancelled = false;
+    setStatus('loading');
+    setError(null);
+    discoverEdgeCases(schemaColumns, sourceStats, sourceId)
+      .then((resp) => {
+        if (cancelled) return;
+        if (!resp.suggestions || resp.suggestions.length === 0) {
+          setStatus('empty');
+          setSuggestions([]);
+          return;
+        }
+        setSuggestions(resp.suggestions);
+        setStatus('ready');
+      })
+      .catch((err) => {
+        if (cancelled) return;
+        setStatus('error');
+        setError(err instanceof Error ? err.message : 'Discovery failed');
+      });
+    return () => {
+      cancelled = true;
+    };
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [schemaKey, sourceId]);
+
+  if (status === 'idle' || status === 'empty') return null;
+
+  const approvedSet = new Set(approvedConditions);
+
+  const toggleApprove = (condition: string) => {
+    const next = approvedSet.has(condition)
+      ? approvedConditions.filter((c) => c !== condition)
+      : [...approvedConditions, condition];
+    onApprovedChange(next);
+  };
+
+  return (
+    <div className="ws-eds-card">
+      <div className="ws-eds-header">
+        <div className="ws-eds-title">Discovered Edge Cases</div>
+        <div className="ws-eds-subtitle">
+          {status === 'loading'
+            ? 'Scanning source data for under-represented patterns…'
+            : status === 'error'
+              ? error ?? 'Discovery failed'
+              : `${suggestions.length} pattern${suggestions.length === 1 ? '' : 's'} found · click to enforce`}
+        </div>
+      </div>
+
+      {status === 'loading' && (
+        <div className="ws-eds-loading">
+          <div className="ws-typing">
+            <span className="ws-typing-dot" />
+            <span className="ws-typing-dot" />
+            <span className="ws-typing-dot" />
+          </div>
+        </div>
+      )}
+
+      {status === 'error' && (
+        <div className="ws-eds-empty">
+          Edge-case discovery unavailable on this run. Generation will proceed without suggested
+          patterns.
+        </div>
+      )}
+
+      {status === 'ready' && (
+        <div className="ws-eds-list">
+          {suggestions.map((s, i) => {
+            const approved = approvedSet.has(s.condition_text);
+            const expanded = expandedIdx === i;
+            return (
+              <div
+                key={`${s.condition_text}-${i}`}
+                className={`ws-eds-chip ws-eds-chip-${s.severity}${
+                  approved ? ' ws-eds-chip-approved' : ''
+                }`}
+              >
+                <button
+                  type="button"
+                  className="ws-eds-chip-main"
+                  onClick={() => toggleApprove(s.condition_text)}
+                  aria-pressed={approved}
+                >
+                  <span className="ws-eds-chip-icon">
+                    {approved ? <Check size={11} strokeWidth={2.5} /> : <Plus size={11} strokeWidth={2.5} />}
+                  </span>
+                  <span className="ws-eds-chip-condition">{s.condition_text}</span>
+                  <span className="ws-eds-chip-meta">
+                    <span className="ws-eds-chip-source">source {pctText(s.source_pct)}</span>
+                    <span className="ws-eds-chip-sep">·</span>
+                    <span className={`ws-eds-chip-severity ws-eds-sev-${s.severity}`}>
+                      {severityLabel(s.severity)}
+                    </span>
+                  </span>
+                </button>
+                <button
+                  type="button"
+                  className="ws-eds-chip-why"
+                  onClick={() => setExpandedIdx(expanded ? null : i)}
+                  aria-expanded={expanded}
+                >
+                  {expanded ? 'Hide' : 'Why?'}
+                </button>
+                {expanded && (
+                  <div className="ws-eds-chip-reason">
+                    <div className="ws-eds-chip-reason-tag">
+                      {detectorLabel(s.detector)} · target {s.suggested_target_pct}%
+                    </div>
+                    <div>{s.reason}</div>
+                  </div>
+                )}
+              </div>
+            );
+          })}
+        </div>
+      )}
+
+      {status === 'ready' && approvedConditions.length > 0 && (
+        <div className="ws-eds-footer">
+          {approvedConditions.length} edge case{approvedConditions.length === 1 ? '' : 's'} approved
+          · will be enforced on next generation
+        </div>
+      )}
+    </div>
+  );
+}

--- a/frontend/src/styles/workspace.css
+++ b/frontend/src/styles/workspace.css
@@ -1922,3 +1922,192 @@
   margin-bottom: 6px;
   line-height: 1.5;
 }
+
+/* ── Edge-Case Discovery (chip strip) ─────────────────────────────────── */
+
+.ws-eds-card {
+  margin-top: 16px;
+  background: var(--surface);
+  border: 1px solid var(--border);
+  border-radius: 12px;
+  padding: 14px 18px;
+}
+
+.ws-eds-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: baseline;
+  gap: 12px;
+  margin-bottom: 12px;
+}
+
+.ws-eds-title {
+  font-size: 13px;
+  font-weight: 500;
+  color: var(--text);
+  letter-spacing: 0.02em;
+}
+
+.ws-eds-subtitle {
+  font-size: 11px;
+  color: var(--text-muted);
+}
+
+.ws-eds-loading {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 8px 0 14px;
+}
+
+.ws-eds-empty {
+  font-size: 12px;
+  color: var(--text-muted);
+  padding: 8px 0;
+}
+
+.ws-eds-list {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+
+.ws-eds-chip {
+  display: grid;
+  grid-template-columns: 1fr auto;
+  align-items: center;
+  gap: 8px;
+  background: var(--bg);
+  border: 1px solid var(--border);
+  border-left: 3px solid var(--border);
+  border-radius: 6px;
+  padding: 0;
+  transition: background 0.15s ease, border-color 0.15s ease;
+}
+
+.ws-eds-chip-high { border-left-color: #c0524a; }
+.ws-eds-chip-medium { border-left-color: #c89b3c; }
+.ws-eds-chip-low { border-left-color: #6b7a8f; }
+
+.ws-eds-chip:hover {
+  background: rgba(255, 255, 255, 0.02);
+}
+
+.ws-eds-chip-approved {
+  background: rgba(122, 154, 109, 0.08);
+  border-color: rgba(122, 154, 109, 0.4);
+}
+
+.ws-eds-chip-approved.ws-eds-chip-high { border-left-color: #7a9a6d; }
+.ws-eds-chip-approved.ws-eds-chip-medium { border-left-color: #7a9a6d; }
+.ws-eds-chip-approved.ws-eds-chip-low { border-left-color: #7a9a6d; }
+
+.ws-eds-chip-main {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  background: none;
+  border: none;
+  color: inherit;
+  cursor: pointer;
+  padding: 10px 14px;
+  font: inherit;
+  text-align: left;
+  min-width: 0;
+}
+
+.ws-eds-chip-icon {
+  width: 16px;
+  height: 16px;
+  border-radius: 50%;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  color: var(--text-muted);
+  flex-shrink: 0;
+}
+
+.ws-eds-chip-approved .ws-eds-chip-icon {
+  background: var(--accent);
+  color: white;
+}
+
+.ws-eds-chip-condition {
+  font-family: var(--mono);
+  font-size: 12px;
+  color: var(--text);
+  flex: 1;
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.ws-eds-chip-meta {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  font-size: 11px;
+  color: var(--text-muted);
+  flex-shrink: 0;
+}
+
+.ws-eds-chip-source {
+  font-family: var(--mono);
+}
+
+.ws-eds-chip-sep {
+  opacity: 0.5;
+}
+
+.ws-eds-chip-severity {
+  font-size: 10px;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+  font-weight: 500;
+}
+
+.ws-eds-sev-high { color: #d97c75; }
+.ws-eds-sev-medium { color: #d8b465; }
+.ws-eds-sev-low { color: #9aa6b8; }
+
+.ws-eds-chip-why {
+  background: none;
+  border: none;
+  color: var(--text-dim);
+  font-size: 11px;
+  padding: 0 14px;
+  cursor: pointer;
+  height: 100%;
+}
+
+.ws-eds-chip-why:hover {
+  color: var(--text);
+}
+
+.ws-eds-chip-reason {
+  grid-column: 1 / -1;
+  padding: 10px 16px 12px 40px;
+  font-size: 12px;
+  color: var(--text-muted);
+  border-top: 1px solid var(--border);
+  line-height: 1.5;
+}
+
+.ws-eds-chip-reason-tag {
+  font-size: 10px;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: var(--text-dim);
+  margin-bottom: 4px;
+  font-weight: 500;
+}
+
+.ws-eds-footer {
+  margin-top: 10px;
+  padding-top: 10px;
+  border-top: 1px solid var(--border);
+  font-size: 11px;
+  color: var(--accent);
+  letter-spacing: 0.02em;
+}


### PR DESCRIPTION
Phase 3 closes the detect → suggest → user-approves → enforce → report loop.

New EdgeCaseSuggestions component renders ranked chips after schema inference completes. Each chip shows the condition, source%, severity badge, and an expandable Why? block with the detector type, suggested target%, and rationale.

Clicking a chip toggles approval; approved conditions are merged into the edge_cases array sent to both /api/preview and /api/generate, so approvals are enforced in the very next call. The existing edge-case enforcer guarantees coverage and the validation report shows Met/Short/Unparsed for each.

Discovery fires automatically once schema + sourceStats are populated. Loading shows typing-dot animation. Empty results, errors, and silent LLM fallback all render gracefully without breaking the rest of the workspace flow.

Stacks on feat/edge-case-discovery-phase-2 !!