### PR TITLE
Add pytest suite, GitHub Actions CI, Dockerfile, and Makefile

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,40 @@
+name: tests
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+jobs:
+  pytest:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    defaults:
+      run:
+        working-directory: backend
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Python 3.11
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+          cache: pip
+
+      - name: Install Poetry
+        run: |
+          curl -sSL https://install.python-poetry.org | python3 -
+          echo "$HOME/.local/bin" >> $GITHUB_PATH
+
+      - name: Cache Poetry virtualenv
+        uses: actions/cache@v4
+        with:
+          path: ~/.cache/pypoetry
+          key: poetry-${{ runner.os }}-${{ hashFiles('backend/poetry.lock') }}
+
+      - name: Install dependencies
+        run: poetry install --no-interaction --no-ansi
+
+      - name: Run pytest
+        run: poetry run pytest tests/ -v --tb=short

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -33,6 +33,9 @@ jobs:
           path: ~/.cache/pypoetry
           key: poetry-${{ runner.os }}-${{ hashFiles('backend/poetry.lock') }}
 
+      - name: Sync lockfile with pyproject
+        run: poetry lock
+
       - name: Install dependencies
         run: poetry install --no-interaction --no-ansi
 

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,33 @@
+# Aperture — developer convenience targets.
+# Run from the repo root: `make test`, `make serve`, `make build`, etc.
+
+.PHONY: help install test test-cov serve build run docker-build docker-run clean
+
+PYTHON ?= python3
+
+help:                ## Show this help
+	@grep -E '^[a-zA-Z_-]+:.*?## ' $(MAKEFILE_LIST) | \
+		awk 'BEGIN {FS = ":.*?## "}; {printf "  \033[36m%-18s\033[0m %s\n", $$1, $$2}'
+
+install:             ## Install backend dependencies via Poetry
+	cd backend && poetry install --no-interaction
+
+test:                ## Run the pytest suite
+	cd backend && poetry run pytest tests/ -v --tb=short
+
+test-cov:            ## Run tests with coverage report
+	cd backend && poetry run pytest tests/ --cov=services --cov-report=term-missing
+
+serve:               ## Start the FastAPI dev server on :8000
+	cd backend && poetry run uvicorn main:app --reload --port 8000
+
+docker-build:        ## Build the backend Docker image
+	cd backend && docker build -t aperture-backend .
+
+docker-run:          ## Run the backend image and expose :8000
+	docker run --rm -p 8000:8000 aperture-backend
+
+clean:               ## Remove caches + .pyc files
+	find . -type d -name __pycache__ -exec rm -rf {} + 2>/dev/null || true
+	find . -type d -name ".pytest_cache" -exec rm -rf {} + 2>/dev/null || true
+	find . -type f -name "*.pyc" -delete

--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -1,0 +1,34 @@
+# Aperture backend image.
+# Build:   docker build -t aperture-backend .
+# Run:     docker run --rm -p 8000:8000 aperture-backend
+# Health:  curl http://localhost:8000/health
+FROM python:3.11-slim AS base
+
+ENV PYTHONDONTWRITEBYTECODE=1 \
+    PYTHONUNBUFFERED=1 \
+    PIP_NO_CACHE_DIR=1 \
+    PIP_DISABLE_PIP_VERSION_CHECK=1 \
+    POETRY_VERSION=2.0.0 \
+    POETRY_VIRTUALENVS_CREATE=false
+
+# Build deps for xgboost / scikit-learn wheels.
+RUN apt-get update && apt-get install -y --no-install-recommends \
+        build-essential curl libgomp1 \
+    && rm -rf /var/lib/apt/lists/*
+
+RUN curl -sSL https://install.python-poetry.org | python3 -
+ENV PATH="/root/.local/bin:${PATH}"
+
+WORKDIR /app
+
+# Dependency layer (cached unless lock changes).
+COPY pyproject.toml poetry.lock ./
+RUN poetry install --no-interaction --no-ansi --without dev || \
+    poetry install --no-interaction --no-ansi
+
+# Application layer.
+COPY . .
+
+EXPOSE 8000
+
+CMD ["uvicorn", "main:app", "--host", "0.0.0.0", "--port", "8000"]

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -26,6 +26,17 @@ scikit-learn = ">=1.4.0"
 pyyaml = ">=6.0"
 imbalanced-learn = ">=0.12.0"
 
+[tool.poetry.group.dev.dependencies]
+pytest = ">=8.0.0"
+pytest-cov = ">=4.1.0"
+
+[tool.pytest.ini_options]
+testpaths = ["tests"]
+python_files = "test_*.py"
+python_classes = "Test*"
+python_functions = "test_*"
+addopts = "--strict-markers -ra"
+
 [build-system]
 requires = ["poetry-core>=2.0.0"]
 build-backend = "poetry.core.masonry.api"

--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -1,0 +1,99 @@
+"""Shared fixtures for the Aperture backend test suite.
+
+Tests run against deterministic synthetic data — no real PII, no Sherlock,
+no Kaggle downloads. Datasets are small (~40-60 rows) so the whole suite
+finishes in seconds.
+"""
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import numpy as np
+import pandas as pd
+import pytest
+
+# Make `services.*`, `models.*`, `core.*` importable in tests (mirrors how the
+# FastAPI server runs from inside backend/).
+BACKEND_ROOT = Path(__file__).resolve().parent.parent
+if str(BACKEND_ROOT) not in sys.path:
+    sys.path.insert(0, str(BACKEND_ROOT))
+
+
+@pytest.fixture(scope="session")
+def rng() -> np.random.Generator:
+    """A seeded RNG so tests are deterministic across runs."""
+    return np.random.default_rng(42)
+
+
+@pytest.fixture
+def insurance_df(rng) -> pd.DataFrame:
+    """Toy insurance frame with all the columns the rule pack expects.
+
+    Mix of clean rows and rows designed to violate specific rules. 40 rows so
+    that aggregate tests (e.g. Spearman) have enough samples and stratified
+    train/test splits don't collapse.
+    """
+    rows = []
+    for i in range(40):
+        rows.append({
+            "age": int(rng.integers(20, 70)),
+            "incident_type": rng.choice(
+                ["Multi-vehicle Collision", "Single Vehicle Collision", "Vehicle Theft", "Parked Car"]
+            ),
+            "collision_type": rng.choice(["Rear Collision", "Side Collision", "Front Collision", "?"]),
+            "property_damage": rng.choice(["YES", "NO"]),
+            "bodily_injuries": int(rng.integers(0, 3)),
+            "number_of_vehicles_involved": int(rng.integers(1, 4)),
+            "injury_claim": int(rng.integers(0, 8000)),
+            "property_claim": int(rng.integers(0, 8000)),
+            "vehicle_claim": int(rng.integers(0, 8000)),
+            "total_claim_amount": 0,             # filled below to satisfy C1
+            "fraud_reported": "N" if i % 9 != 0 else "Y",
+        })
+    df = pd.DataFrame(rows)
+    df["total_claim_amount"] = df["injury_claim"] + df["property_claim"] + df["vehicle_claim"]
+    return df
+
+
+@pytest.fixture
+def clinical_df(rng) -> pd.DataFrame:
+    """Toy clinical frame compatible with the clinical rule pack."""
+    return pd.DataFrame([
+        {"age": 45, "sex": "F", "hba1c": 5.2, "diagnosis": "routine",
+         "heart_rate": 72, "blood_pressure_systolic": 120, "temperature": 36.6,
+         "medication": "aspirin"},
+        {"age": 60, "sex": "M", "hba1c": 7.8, "diagnosis": "diabetes type 2",
+         "heart_rate": 80, "blood_pressure_systolic": 130, "temperature": 36.9,
+         "medication": "metformin 500mg"},
+        {"age": 35, "sex": "F", "hba1c": 5.0, "diagnosis": "asthma",
+         "heart_rate": 75, "blood_pressure_systolic": 125, "temperature": 36.7,
+         "medication": "albuterol"},
+        {"age": 50, "sex": "M", "hba1c": 5.5, "diagnosis": "hypertension",
+         "heart_rate": 78, "blood_pressure_systolic": 138, "temperature": 36.8,
+         "medication": "lisinopril"},
+    ] * 12)  # 48 rows so utility/diagnostics have enough samples
+
+
+@pytest.fixture
+def leaky_synth(insurance_df) -> pd.DataFrame:
+    """Synthetic frame that literally copies real rows — privacy disaster case."""
+    return insurance_df.sample(20, random_state=1).reset_index(drop=True)
+
+
+@pytest.fixture
+def private_synth(insurance_df, rng) -> pd.DataFrame:
+    """Synthetic frame drawn independently from the same distribution — privacy ideal."""
+    return pd.DataFrame({
+        "age": rng.integers(20, 70, 20),
+        "incident_type": rng.choice(insurance_df["incident_type"].unique(), 20),
+        "collision_type": rng.choice(insurance_df["collision_type"].unique(), 20),
+        "property_damage": rng.choice(["YES", "NO"], 20),
+        "bodily_injuries": rng.integers(0, 3, 20),
+        "number_of_vehicles_involved": rng.integers(1, 4, 20),
+        "injury_claim": rng.integers(0, 8000, 20),
+        "property_claim": rng.integers(0, 8000, 20),
+        "vehicle_claim": rng.integers(0, 8000, 20),
+        "total_claim_amount": rng.integers(5000, 25000, 20),
+        "fraud_reported": rng.choice(["N", "Y"], 20, p=[0.9, 0.1]),
+    })

--- a/backend/tests/test_llm_auditor.py
+++ b/backend/tests/test_llm_auditor.py
@@ -1,0 +1,33 @@
+"""Tests for the LLM auditor (heuristic mode — no real Claude call)."""
+from __future__ import annotations
+
+import pandas as pd
+
+from services.llm_auditor import audit_sample
+
+
+def test_audit_sample_returns_unavailable_for_empty():
+    result = audit_sample(pd.DataFrame())
+    assert result["available"] is False
+
+
+def test_audit_sample_heuristic_runs_on_clean_data(insurance_df):
+    result = audit_sample(insurance_df, use_llm=False)
+    assert result["available"] is True
+    assert result["mode"] == "heuristic"
+    assert "mean_plausibility" in result
+    assert 0.0 <= result["mean_plausibility"] <= 1.0
+
+
+def test_audit_sample_flags_negative_claims(insurance_df):
+    """The heuristic should drop plausibility when claim columns go negative."""
+    leaky = insurance_df.copy()
+    leaky.loc[:5, "injury_claim"] = -500
+    result = audit_sample(leaky, use_llm=False)
+    assert result["n_flagged"] > 0, "negative injury_claim rows should be flagged"
+
+
+def test_audit_sample_caps_at_sample_size(insurance_df):
+    """audit_sample should not iterate over more than `sample_size` rows."""
+    result = audit_sample(insurance_df, sample_size=10, use_llm=False)
+    assert result["n_sampled"] <= 10

--- a/backend/tests/test_pillar_integration.py
+++ b/backend/tests/test_pillar_integration.py
@@ -1,0 +1,57 @@
+"""End-to-end pillar composition test.
+
+Runs the full evaluation chain that /api/generate fires (minus HTTP) on a
+deterministic synthetic frame, and asserts that no pillar throws and that
+every pillar produces an output of the expected shape. This is the
+'something is broken somewhere' canary test.
+"""
+from __future__ import annotations
+
+import numpy as np
+import pandas as pd
+
+from services.llm_auditor import audit_sample
+from services.rule_packs import apply_pack
+from services.utility import compute_utility
+
+
+def _make_classification_frame(n: int, seed: int) -> pd.DataFrame:
+    rng = np.random.default_rng(seed)
+    return pd.DataFrame({
+        "age": rng.integers(18, 80, n),
+        "feature_a": rng.normal(0, 1, n),
+        "feature_b": rng.normal(0, 1, n),
+        "incident_type": rng.choice(
+            ["Multi-vehicle Collision", "Single Vehicle Collision"], n
+        ),
+        "collision_type": rng.choice(["Rear Collision", "Side Collision", "?"], n),
+        "property_damage": rng.choice(["YES", "NO"], n),
+        "bodily_injuries": rng.integers(0, 3, n),
+        "number_of_vehicles_involved": rng.integers(1, 4, n),
+        "injury_claim": rng.integers(0, 5000, n),
+        "property_claim": rng.integers(0, 5000, n),
+        "vehicle_claim": rng.integers(0, 5000, n),
+        "total_claim_amount": rng.integers(5000, 15000, n),
+        "fraud_reported": rng.choice(["N", "Y"], n, p=[0.85, 0.15]),
+    })
+
+
+def test_pillars_compose_without_throwing():
+    """utility -> rule_packs -> audit must all run sequentially on the same frame."""
+    real = _make_classification_frame(300, seed=42)
+    synth = _make_classification_frame(300, seed=43)
+
+    rule_report = apply_pack(synth)
+    assert rule_report is not None, "rule pack should detect insurance domain"
+    synth_repaired = rule_report.pop("repaired_df")
+
+    utility = compute_utility(real, synth_repaired)
+    assert utility is not None and utility["available"] is True
+
+    audit = audit_sample(synth_repaired, rule_pack_report=rule_report, use_llm=False)
+    assert audit["available"] is True
+
+    # Sanity: each pillar's "verdict" / "status" string is non-empty.
+    assert isinstance(utility["verdict"], str) and utility["verdict"]
+    assert "violations_before" in rule_report and "violations_after" in rule_report
+    assert "mean_plausibility" in audit

--- a/backend/tests/test_rule_packs.py
+++ b/backend/tests/test_rule_packs.py
@@ -1,0 +1,64 @@
+"""Tests for the rule pack engine."""
+from __future__ import annotations
+
+import pandas as pd
+
+from services.rule_packs import apply_pack, check_pack, detect_pack, load_pack, repair
+
+
+def test_load_pack_returns_insurance_dict():
+    pack = load_pack("insurance")
+    assert pack is not None, "insurance.yaml must be loadable"
+    assert pack["pack"] == "insurance"
+    assert len(pack["rules"]) >= 7, "insurance pack should have at least the original 7 rules"
+
+
+def test_load_pack_returns_clinical_dict():
+    pack = load_pack("clinical")
+    assert pack is not None
+    assert pack["pack"] == "clinical"
+
+
+def test_load_pack_returns_none_for_unknown():
+    assert load_pack("does_not_exist") is None
+
+
+def test_detect_pack_insurance(insurance_df):
+    assert detect_pack(insurance_df) == "insurance"
+
+
+def test_detect_pack_clinical(clinical_df):
+    assert detect_pack(clinical_df) == "clinical"
+
+
+def test_detect_pack_unknown_schema():
+    df = pd.DataFrame([{"customer_id": 1, "amount": 100, "country": "US"}])
+    assert detect_pack(df) is None
+
+
+def test_check_pack_returns_structured_report(insurance_df):
+    pack = load_pack("insurance")
+    report = check_pack(insurance_df, pack)
+    assert "rules" in report and isinstance(report["rules"], list)
+    assert report["n_rows"] == len(insurance_df)
+    assert "total_violations" in report
+
+
+def test_repair_does_not_mutate_input(insurance_df):
+    pack = load_pack("insurance")
+    snapshot = insurance_df.copy()
+    _ = repair(insurance_df, pack)
+    pd.testing.assert_frame_equal(insurance_df, snapshot)
+
+
+def test_apply_pack_full_pipeline_round_trips(insurance_df):
+    """The whole point of the engine: violations_after should be <= violations_before."""
+    report = apply_pack(insurance_df)
+    assert report is not None
+    assert report["violations_after"] <= report["violations_before"]
+    assert "repaired_df" in report and len(report["repaired_df"]) == len(insurance_df)
+
+
+def test_apply_pack_returns_none_for_unknown_schema():
+    df = pd.DataFrame([{"foo": 1, "bar": "x"}])
+    assert apply_pack(df) is None

--- a/backend/tests/test_utility.py
+++ b/backend/tests/test_utility.py
@@ -1,0 +1,47 @@
+"""Tests for the utility (TRTR / TSTR / TR+STR) pillar."""
+from __future__ import annotations
+
+import numpy as np
+import pandas as pd
+
+from services.utility import compute_utility
+
+
+def _make_classification_frame(n: int, rng: np.random.Generator) -> pd.DataFrame:
+    """A simple binary-fraud frame the utility pillar can actually train on."""
+    return pd.DataFrame({
+        "feature_a": rng.normal(0, 1, n),
+        "feature_b": rng.normal(0, 1, n),
+        "feature_c": rng.choice(["x", "y", "z"], n),
+        "fraud_reported": rng.choice(["N", "Y"], n, p=[0.8, 0.2]),
+    })
+
+
+def test_compute_utility_returns_none_when_real_df_missing(rng):
+    synth = _make_classification_frame(80, rng)
+    assert compute_utility(None, synth) is None
+
+
+def test_compute_utility_returns_none_when_too_few_real(rng):
+    real = _make_classification_frame(10, rng)        # below the 50-row floor
+    synth = _make_classification_frame(80, rng)
+    assert compute_utility(real, synth) is None
+
+
+def test_compute_utility_full_pipeline_produces_three_regimes(rng):
+    real = _make_classification_frame(300, rng)
+    synth = _make_classification_frame(300, rng)
+    result = compute_utility(real, synth)
+    assert result is not None, "expected utility result with sufficient real data"
+    assert result["available"] is True
+    for regime in ("trtr", "tstr", "augmented"):
+        assert regime in result, f"{regime} should be present"
+        for metric in ("auc", "f1", "recall"):
+            assert metric in result[regime]
+
+
+def test_compute_utility_verdict_is_a_sentence(rng):
+    real = _make_classification_frame(300, rng)
+    synth = _make_classification_frame(300, rng)
+    result = compute_utility(real, synth)
+    assert isinstance(result["verdict"], str) and len(result["verdict"]) > 10


### PR DESCRIPTION
Foundation work so the team can run the backend reproducibly and so every PR gets automatic test coverage. Closes the "no tests, no CI, no Docker" gap visible in the day-1 deck.

Tests (backend/tests/, 19 cases, ~1s total)
- test_rule_packs.py     load_pack / detect_pack / check_pack / repair / apply_pack
                         round-trip + immutability + None-on-unknown-schema
- test_utility.py        TRTR/TSTR/TR+STR returns all three regimes; guard
                         conditions for missing real_df + too-few rows; verdict
                         is a non-empty sentence
- test_llm_auditor.py    heuristic mode flags negative claim columns; respects
                         sample_size; degrades on empty input
- test_pillar_integration.py  end-to-end canary: rule_packs -> utility ->
                              audit composes without throwing
- conftest.py            deterministic fixtures (seeded RNG, toy insurance +
                         clinical frames). No real PII, no Kaggle downloads.

CI (.github/workflows/test.yml)
- Triggers on push + PR to main
- Python 3.11, Poetry install, pip and Poetry caches
- Runs `poetry run pytest tests/ -v --tb=short` from backend/
- 10-minute timeout

Docker (backend/Dockerfile)
- python:3.11-slim base, build-essential + libgomp1 (xgboost wheels)
- Poetry install layer cached separately from app layer
- Exposes 8000, default CMD runs `uvicorn main:app --host 0.0.0.0 --port 8000`

Makefile (repo root)
- make help / install / test / test-cov / serve / docker-build / docker-run / clean

pyproject.toml
- Adds pytest + pytest-cov to a [dev] group
- Adds [tool.pytest.ini_options] so `pytest` from the backend root discovers tests/ automatically