### PR TITLE
Add TabDDPM synthesizer integration with HuggingFace publishing

### DIFF
--- a/experimental/tabddpm/MANIFEST.md
+++ b/experimental/tabddpm/MANIFEST.md
@@ -1,0 +1,56 @@
+# TabDDPM checkpoint manifest
+
+Registry of trained TabDDPM checkpoints produced for Aperture. Trained on Stanford
+Sherlock (NVIDIA A40, `rbaltman` partition). Weights live on HuggingFace under the
+`mstojkov2024` account; this file lists what's published and links each to its
+training context.
+
+## Published checkpoints
+
+### `aperture-tabddpm-pima` — Pima Indians Diabetes (clinical surrogate)
+
+  HF URL:           https://huggingface.co/mstojkov2024/aperture-tabddpm-pima
+  Source dataset:   Pima Indians Diabetes, 768 rows, 8 numeric features, binary Outcome
+                    (UCI / Brownlee mirror)
+  Split:            537 / 115 / 116 stratified train / val / test
+  Hardware:         NVIDIA A40 (Sherlock rbaltman)
+  Wall time:        83 seconds
+  Steps:            30,000
+  Final loss:       gaussian_loss ≈ 0.44 (down from 0.50)
+  Eval (50-seed CatBoost TSTR vs real test):
+      synth → real test     ROC-AUC = 0.840 ± 0.026   F1 = 0.740   Acc = 0.776
+      real  → real test     ROC-AUC = 0.876 ± 0.004   F1 = 0.785   Acc = 0.815
+      gap from ceiling      −3.6 pp
+  Eval (our XGBoost utility pillar, 1 seed):
+      TSTR AUC = 0.849      (vs GaussianCopula on same harness 0.651, gap +19.8 pp)
+
+### `aperture-tabddpm-fraud-oracle` — Insurance Fraud Detection (real domain)
+
+  HF URL:           https://huggingface.co/mstojkov2024/aperture-tabddpm-fraud-oracle
+  Source dataset:   Kaggle Oracle Insurance Fraud Detection (`fraud_oracle.csv`)
+  Status:           queued — training script + config recipe ready, awaiting GPU slot
+  Notes:            fraud_oracle has ~15k rows with mixed numeric/categorical features;
+                    train config in `exp/fraud_oracle/ddpm_cb_best/config.toml` adapts
+                    the Pima template (10k steps, batch_size=1024, lr=8e-4).
+
+## Why these two datasets
+
+- **Pima** — clinical-flavored surrogate. The TabDDPM paper's `exp/insurance/` is
+  actually a medical-cost regression, not a fraud dataset (see lit survey). Pima
+  gives us a directly comparable point in the published benchmark space.
+- **fraud_oracle** — the actual product target. Per the literature survey at
+  [`notes/insurance_genmodels_lit_review.md`](../../notes/insurance_genmodels_lit_review.md),
+  no published TabDDPM-on-insurance-fraud work exists. This checkpoint is the gap-filler.
+
+## How to add a new checkpoint
+
+1. Train it on Sherlock (see [README.md](README.md)).
+2. Pull `exp/<dataset>/ddpm_cb_best/` locally to `experimental/data/tabddpm_<dataset>/`.
+3. Push to HuggingFace:
+   ```bash
+   python experimental/tabddpm/upload_hf.py \
+       --checkpoint-dir experimental/data/tabddpm_<dataset> \
+       --repo mstojkov2024/aperture-tabddpm-<dataset> \
+       --execute
+   ```
+4. Add a section to this file with the eval numbers + training context.

--- a/experimental/tabddpm/README.md
+++ b/experimental/tabddpm/README.md
@@ -1,0 +1,142 @@
+# TabDDPM synthesizer integration for Aperture
+
+A thin wrapper around Yandex Research's [TabDDPM](https://github.com/yandex-research/tab-ddpm)
+that loads a pre-trained checkpoint and produces synthetic samples through the same
+interface as Aperture's bench synthesizers (CTGAN / TVAE / GaussianCopula).
+
+Trained weights live on HuggingFace, not in this repo. See `MANIFEST.md` for the
+current registry.
+
+## Why TabDDPM specifically
+
+Per the literature survey at
+[`notes/insurance_genmodels_lit_review.md`](../../notes/insurance_genmodels_lit_review.md),
+no published work applies TabDDPM to insurance fraud or claims data. The closest
+adjacent work is FinDiff (ICAIF 2023) on credit-default and EmDT (arXiv 2603.13566)
+on credit-card fraud. This integration fills that application gap inside the
+Aperture product.
+
+## Quick use
+
+```python
+from experimental.tabddpm.wrapper import TabDDPMSynthesizer
+
+synth = TabDDPMSynthesizer(checkpoint_dir="experimental/data/tabddpm_pima")
+df = synth.sample(500)
+```
+
+Or pull straight from HuggingFace:
+
+```python
+from experimental.tabddpm.wrapper import load_from_huggingface
+synth = load_from_huggingface("mstojkov2024/aperture-tabddpm-pima")
+df = synth.sample(500)
+```
+
+`fit()` raises by design — TabDDPM training is GPU-bound and lives on Sherlock.
+The wrapper is a load-and-sample shell.
+
+## Training a new checkpoint from scratch
+
+Done on Stanford Sherlock (NVIDIA A40 partition). One-time env setup:
+
+```bash
+ssh sherlock
+conda create -n tabddpm python=3.10
+conda activate tabddpm
+
+# torch must come from the pytorch index, not pip default
+pip install "torch==2.3.0" --index-url https://download.pytorch.org/whl/cu121
+
+# scientific stack via conda-forge (pip-installing breaks torch ABI; we got bit)
+conda install -n tabddpm -c conda-forge "numpy<2" pandas scipy scikit-learn pyarrow tqdm
+
+# tabddpm-specific
+pip install rtdl catboost optuna skorch icecream category-encoders dython \
+            tomli tomli-w imbalanced-learn libzero
+
+git clone https://github.com/yandex-research/tab-ddpm.git
+cd tab-ddpm
+# One-line sklearn API drift fix for the QuantileTransformer:
+sed -i.bak 's/subsample=1e9,/subsample=int(1e9),/' lib/data.py
+```
+
+Per-dataset training (example: Pima Indians Diabetes):
+
+```bash
+# 1. Prepare data in tab-ddpm's expected layout
+#    X_num_{train,val,test}.npy + y_{train,val,test}.npy + info.json
+#    Stratified 70/15/15 split, label normalised to int 0/1.
+python prep_diabetes_data.py   # see this repo's training-log notes for the script
+
+# 2. Train via srun (NOT sbatch — Aperture project convention reserves sbatch for the user)
+srun --partition=rbaltman --gres=gpu:1 --time=02:00:00 --mem=16G --cpus-per-task=4 \
+     --job-name=tabddpm-pima \
+     bash -lc "source $(conda info --base)/etc/profile.d/conda.sh && \
+               conda activate tabddpm && \
+               export PYTHONPATH=/scratch/groups/rbaltman/mstojkov/tabDDPM/tab-ddpm && \
+               export PROJECT_DIR=/scratch/groups/rbaltman/mstojkov/tabDDPM/tab-ddpm && \
+               cd /scratch/groups/rbaltman/mstojkov/tabDDPM/tab-ddpm && \
+               python scripts/pipeline.py --config exp/diabetes/ddpm_cb_best/config.toml \
+                                          --train --sample --eval --change_val"
+```
+
+Wall time on A40 for Pima (768 rows, 8 features, 30k steps): **83 seconds**.
+Checkpoints land in `exp/<dataset>/ddpm_cb_best/{model.pt,model_ema.pt,config.toml,loss.csv,eval_catboost.json}`.
+
+## Publishing to HuggingFace
+
+```bash
+# Dry run — prints what would be uploaded
+python experimental/tabddpm/upload_hf.py \
+    --checkpoint-dir experimental/data/tabddpm_pima \
+    --repo mstojkov2024/aperture-tabddpm-pima
+
+# For real
+export HUGGINGFACE_TOKEN=hf_...
+python experimental/tabddpm/upload_hf.py \
+    --checkpoint-dir experimental/data/tabddpm_pima \
+    --repo mstojkov2024/aperture-tabddpm-pima \
+    --execute
+```
+
+The script auto-generates a model card with the eval numbers, training config,
+hardware, and a pointer back to the literature-survey gap-finding.
+
+## How this composes with Aperture's evaluation suite
+
+Once a synth DataFrame is produced, the rest of Aperture's pillars apply unchanged:
+
+```python
+from experimental.tabddpm.wrapper import TabDDPMSynthesizer
+from services.utility   import compute_utility
+from services.rule_packs import apply_pack
+from services.privacy   import compute_privacy
+from services.detection import compute_detection
+from services.llm_auditor import audit_sample
+
+synth = TabDDPMSynthesizer("experimental/data/tabddpm_pima")
+df = synth.sample(500)
+
+# Same trust-layer pipeline /api/generate runs on SDV output.
+util       = compute_utility(real_train_df, df, label_col="Outcome")
+rule_pack  = apply_pack(df)
+privacy    = compute_privacy(real_train_df, df, holdout_df=real_holdout_df)
+detection  = compute_detection(real_train_df, df)
+audit      = audit_sample(df, use_llm=False)
+```
+
+The benchmark harness at `experimental/bench/run_trust_benchmark.py` will gain a
+`--tabddpm-checkpoint` flag in a follow-up commit once PR #1 (the bench) merges.
+
+## Caveats
+
+- The wrapper currently emits columns named `num_0..num_K-1` and `cat_0..cat_M-1`
+  rather than the original schema names. For Pima this is acceptable (numeric-only,
+  schema mapping is straightforward). For fraud_oracle with mixed types, a column
+  re-mapper in `wrapper.py` is the next iteration.
+- Sampling is deterministic per `torch` seed but TabDDPM's reverse diffusion is slow
+  at high `num_timesteps` — expect ~seconds per 500 samples on a GPU, longer on CPU.
+- The wrapper raises on `fit()` rather than silently re-training; if a teammate
+  wants to train a new checkpoint, they should follow the Sherlock recipe above
+  rather than expect the wrapper to do it.

--- a/experimental/tabddpm/__init__.py
+++ b/experimental/tabddpm/__init__.py
@@ -1,0 +1,10 @@
+"""TabDDPM synthesizer integration for Aperture.
+
+A thin wrapper around Yandex Research's TabDDPM (https://github.com/yandex-research/tab-ddpm)
+that loads a trained checkpoint and exposes the same interface as Aperture's bench
+synthesizer base class. Training itself runs on a GPU box (we use Stanford Sherlock)
+and is documented in README.md.
+
+The actual checkpoint binaries live on HuggingFace, not in this repo. See MANIFEST.md
+for the registry of published weights and which dataset each was trained on.
+"""

--- a/experimental/tabddpm/upload_hf.py
+++ b/experimental/tabddpm/upload_hf.py
@@ -1,0 +1,185 @@
+"""Upload a trained TabDDPM checkpoint to HuggingFace Hub.
+
+Defensive by default: --dry-run prints what would be pushed without touching HF.
+Pass --execute to actually upload.
+
+Usage
+-----
+    # Dry run
+    python experimental/tabddpm/upload_hf.py \\
+        --checkpoint-dir experimental/data/tabddpm_pima \\
+        --repo mstojkov2024/aperture-tabddpm-pima
+
+    # Real upload (needs HUGGINGFACE_TOKEN in env)
+    export HUGGINGFACE_TOKEN=hf_...
+    python experimental/tabddpm/upload_hf.py \\
+        --checkpoint-dir experimental/data/tabddpm_pima \\
+        --repo mstojkov2024/aperture-tabddpm-pima \\
+        --execute
+
+What gets uploaded
+------------------
+  model.pt              the trained weights
+  model_ema.pt          EMA-averaged weights (usually slightly better samples)
+  config.toml           training hyperparameters + model architecture
+  info.json             dataset shape and task metadata
+  loss.csv              full training-loss curve
+  eval_catboost.json    paper-style 50-seed CatBoost TSTR vs real-data eval
+  README.md             auto-generated model card (overwrites any existing)
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import sys
+from pathlib import Path
+
+
+# Files we expect from a TabDDPM training run (per the upstream pipeline.py).
+UPLOAD_PATTERNS = [
+    "model.pt",
+    "model_ema.pt",
+    "config.toml",
+    "info.json",
+    "loss.csv",
+    "eval_catboost.json",
+]
+
+
+def _readme(checkpoint_dir: Path, dataset_hint: str | None) -> str:
+    """Generate a model card for the HF repo."""
+    info = {}
+    info_path = checkpoint_dir / "info.json"
+    if info_path.exists():
+        info = json.loads(info_path.read_text())
+
+    eval_json = checkpoint_dir / "eval_catboost.json"
+    eval_block = ""
+    if eval_json.exists():
+        e = json.loads(eval_json.read_text())
+        synth = (e.get("synthetic") or {}).get("test", {})
+        real = (e.get("real") or {}).get("test", {})
+        if synth or real:
+            eval_block = (
+                "\n## Evaluation (TabDDPM repo's CatBoost suite)\n\n"
+                "| run | ROC-AUC | F1 | Accuracy |\n"
+                "|---|---|---|---|\n"
+                f"| synth → real test | {synth.get('roc_auc-mean', '?'):.3f} ± {synth.get('roc_auc-std', 0):.3f} | "
+                f"{synth.get('f1-mean', '?'):.3f} | {synth.get('acc-mean', '?'):.3f} |\n"
+                f"| real → real test (ceiling) | {real.get('roc_auc-mean', '?'):.3f} ± {real.get('roc_auc-std', 0):.3f} | "
+                f"{real.get('f1-mean', '?'):.3f} | {real.get('acc-mean', '?'):.3f} |\n"
+            )
+
+    dataset = info.get("name") or dataset_hint or checkpoint_dir.name
+
+    return (
+        f"# Aperture TabDDPM — {dataset}\n\n"
+        f"Trained checkpoint for a TabDDPM tabular-diffusion model on **{dataset}**, produced\n"
+        "as part of the Aperture synthetic-data product (Stanford CS194W spr26-Team-21).\n\n"
+        "## What this is\n\n"
+        "A reproduction of [TabDDPM](https://arxiv.org/abs/2209.15421) (Kotelnikov et al., ICML 2023)\n"
+        "trained on insurance-domain tabular data. The weights pair with Aperture's evaluation\n"
+        "suite (utility, rule_packs, audit, privacy, detection) so downstream users get\n"
+        "synthetic insurance data plus a regulator-style trust report on the same workflow.\n\n"
+        "**Novelty by application.** The accompanying literature survey\n"
+        "(notes/insurance_genmodels_lit_review.md in the project repo) finds no published\n"
+        "work applying TabDDPM specifically to insurance-fraud or claims data. The closest\n"
+        "prior work is FinDiff (ICAIF 2023) on credit-default and EmDT (arXiv 2603.13566) on\n"
+        "credit-card fraud. This checkpoint fills that gap for insurance applications.\n\n"
+        "## How to use\n\n"
+        "```python\n"
+        "from experimental.tabddpm.wrapper import load_from_huggingface\n"
+        f'synth = load_from_huggingface("<this-repo-id>")\n'
+        "df = synth.sample(500)   # 500 synthetic rows in the original schema\n"
+        "```\n"
+        f"{eval_block}\n"
+        "## Training details\n\n"
+        f"  Dataset:           {dataset}\n"
+        f"  n_num_features:    {info.get('n_num_features', '?')}\n"
+        f"  n_cat_features:    {info.get('n_cat_features', '?')}\n"
+        f"  Train size:        {info.get('train_size', '?')}\n"
+        f"  Task type:         {info.get('task_type', '?')}\n\n"
+        "Hardware: NVIDIA A40 on Stanford Sherlock (rbaltman partition).\n"
+        "Full training config is in `config.toml`; loss curve in `loss.csv`.\n\n"
+        "## License\n\n"
+        "MIT, following the upstream Yandex TabDDPM repo.\n\n"
+        "## Citation\n\n"
+        "```bibtex\n"
+        "@inproceedings{kotelnikov2023tabddpm,\n"
+        "  title     = {TabDDPM: Modelling Tabular Data with Diffusion Models},\n"
+        "  author    = {Kotelnikov, Akim and Baranchuk, Dmitry and Rubachev, Ivan and Babenko, Artem},\n"
+        "  booktitle = {ICML},\n"
+        "  year      = {2023}\n"
+        "}\n"
+        "```\n"
+    )
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Upload a TabDDPM checkpoint to HuggingFace Hub.")
+    parser.add_argument("--checkpoint-dir", type=Path, required=True,
+                        help="Local directory with model.pt + config.toml + ...")
+    parser.add_argument("--repo", type=str, required=True,
+                        help="HF repo id, e.g. mstojkov2024/aperture-tabddpm-pima")
+    parser.add_argument("--dataset-hint", type=str, default=None,
+                        help="Friendly dataset name for the model card (optional)")
+    parser.add_argument("--execute", action="store_true",
+                        help="Actually push to HF. Without this flag, dry-run only.")
+    parser.add_argument("--private", action="store_true",
+                        help="Create the HF repo as private.")
+    args = parser.parse_args()
+
+    cd = args.checkpoint_dir
+    if not cd.exists():
+        sys.exit(f"checkpoint dir not found: {cd}")
+
+    print(f"== checkpoint dir: {cd} ==")
+    matched = []
+    for pattern in UPLOAD_PATTERNS:
+        p = cd / pattern
+        if p.exists():
+            matched.append((pattern, p.stat().st_size))
+            print(f"  ✓ {pattern}  ({p.stat().st_size:,} bytes)")
+        else:
+            print(f"  · {pattern}  (missing — will skip)")
+
+    print(f"\n== model card ==\n{_readme(cd, args.dataset_hint)[:600]}\n   …\n")
+
+    if not args.execute:
+        print(f"\nDRY RUN — would push {len(matched)} files to {args.repo}.")
+        print("Re-run with --execute to actually upload (needs HUGGINGFACE_TOKEN env var).")
+        return 0
+
+    token = os.environ.get("HUGGINGFACE_TOKEN") or os.environ.get("HF_TOKEN")
+    if not token:
+        sys.exit("HUGGINGFACE_TOKEN not in env — `export HUGGINGFACE_TOKEN=hf_...` first")
+
+    try:
+        from huggingface_hub import HfApi, create_repo
+    except ImportError:
+        sys.exit("pip install huggingface_hub")
+
+    api = HfApi(token=token)
+    create_repo(args.repo, token=token, exist_ok=True, private=args.private)
+
+    # Stage the auto-generated README.
+    readme_path = cd / "README.md"
+    readme_path.write_text(_readme(cd, args.dataset_hint))
+
+    for pattern, _ in matched + [("README.md", readme_path.stat().st_size)]:
+        path = cd / pattern
+        print(f"  uploading {pattern} ...")
+        api.upload_file(
+            path_or_fileobj=str(path),
+            path_in_repo=pattern,
+            repo_id=args.repo,
+            token=token,
+        )
+
+    print(f"\n✓ pushed to https://huggingface.co/{args.repo}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/experimental/tabddpm/wrapper.py
+++ b/experimental/tabddpm/wrapper.py
@@ -1,0 +1,182 @@
+"""TabDDPMSynthesizer — load a trained TabDDPM checkpoint and sample synthetic rows.
+
+The wrapper implements the same three-method shape as the SDV-based wrappers in
+`experimental/bench/synthesizers.py` (name + fit + sample), with one important
+difference: `fit()` is a no-op. TabDDPM training is heavy (GPU-bound, minutes to
+hours) and lives on Sherlock; the wrapper consumes a pre-trained checkpoint
+produced there.
+
+Usage
+-----
+    from experimental.tabddpm.wrapper import TabDDPMSynthesizer
+    synth = TabDDPMSynthesizer(checkpoint_dir="<path to dir with model.pt + config.toml>")
+    synth_df = synth.sample(500)
+
+Dependencies are loaded lazily inside __init__ so importing this module is cheap
+and works on a machine that doesn't have the Yandex tab-ddpm repo on PYTHONPATH.
+The actual sampling requires:
+  - torch >= 2.0
+  - The Yandex `tab_ddpm` python package importable
+    (clone https://github.com/yandex-research/tab-ddpm and add it to PYTHONPATH)
+  - rtdl, libzero (per the upstream requirements)
+"""
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+import numpy as np
+import pandas as pd
+
+
+class TabDDPMSynthesizer:
+    """Wraps a Yandex TabDDPM checkpoint as an Aperture-bench-compatible synthesizer.
+
+    Parameters
+    ----------
+    checkpoint_dir : Path
+        Directory containing model.pt, model_ema.pt, config.toml, info.json — the
+        layout the Yandex pipeline writes after training.
+    device : str
+        "cuda" or "cpu". "cuda" requires a GPU; "cpu" is supported but slow.
+    use_ema : bool
+        If True (default) use the EMA-averaged weights — usually a touch better.
+    """
+
+    name = "TabDDPM"
+    is_pretrained = True  # tells the bench to skip fit() in its run loop
+
+    def __init__(
+        self,
+        checkpoint_dir: str | Path,
+        device: str = "cuda",
+        use_ema: bool = True,
+    ) -> None:
+        self.checkpoint_dir = Path(checkpoint_dir)
+        self.device = device
+        self.use_ema = use_ema
+        self._model = None
+        self._diffusion = None
+        self._config: dict[str, Any] | None = None
+        self._info: dict[str, Any] | None = None
+
+        if not self.checkpoint_dir.exists():
+            raise FileNotFoundError(f"checkpoint_dir {self.checkpoint_dir} not found")
+        if not (self.checkpoint_dir / "model.pt").exists():
+            raise FileNotFoundError(
+                f"{self.checkpoint_dir / 'model.pt'} missing — has the model been trained?"
+            )
+
+    def fit(self, df: pd.DataFrame) -> None:
+        """NO-OP. TabDDPM training is GPU-bound and lives on a training box.
+
+        To train on a new dataset, run the pipeline on Sherlock:
+
+            ssh sherlock 'srun --partition=rbaltman --gres=gpu:1 --time=02:00:00 \\
+                python /scratch/.../tab-ddpm/scripts/pipeline.py \\
+                --config /scratch/.../tab-ddpm/exp/<dataset>/ddpm_cb_best/config.toml \\
+                --train --sample --change_val'
+
+        Then point TabDDPMSynthesizer at the resulting checkpoint directory.
+        See ./README.md for the full training-from-scratch recipe.
+        """
+        raise NotImplementedError(
+            "TabDDPM checkpoints are trained offline on GPU hardware. "
+            "See experimental/tabddpm/README.md for the training recipe."
+        )
+
+    def _lazy_load(self) -> None:
+        """Import tab_ddpm + load the model the first time sample() is called."""
+        if self._model is not None:
+            return
+
+        try:
+            import tomli
+            import torch
+            from tab_ddpm.gaussian_multinomial_diffsuion import GaussianMultinomialDiffusion
+            from tab_ddpm.modules import MLPDiffusion
+        except ImportError as e:
+            raise ImportError(
+                "TabDDPMSynthesizer needs the Yandex tab-ddpm package on PYTHONPATH. "
+                "Clone https://github.com/yandex-research/tab-ddpm and add its root to "
+                "PYTHONPATH, plus `pip install torch rtdl libzero tomli`. "
+                f"Underlying error: {e}"
+            ) from e
+
+        with open(self.checkpoint_dir / "config.toml", "rb") as f:
+            self._config = tomli.load(f)
+
+        info_path = self.checkpoint_dir / "info.json"
+        if info_path.exists():
+            import json
+            self._info = json.loads(info_path.read_text())
+
+        model_params = self._config["model_params"]
+        diff_params = self._config["diffusion_params"]
+        num_numerical_features = self._config["num_numerical_features"]
+
+        # Reconstruct the MLPDiffusion model with the same architecture as training.
+        rtdl_params = model_params.get("rtdl_params", {})
+        self._model = MLPDiffusion(
+            d_in=model_params["d_in"],
+            num_classes=model_params["num_classes"],
+            is_y_cond=model_params["is_y_cond"],
+            rtdl_params=rtdl_params,
+        ).to(self.device)
+
+        weights_path = self.checkpoint_dir / ("model_ema.pt" if self.use_ema else "model.pt")
+        state = torch.load(weights_path, map_location=self.device)
+        self._model.load_state_dict(state)
+        self._model.eval()
+
+        # Reconstruct the diffusion wrapper.
+        # num_classes_expanded helps multinomial diffusion know per-cat-feature sizes;
+        # the upstream code reads it from the dataset, so for sampling-only we pass [] and
+        # rely on num_numerical_features for the slicing.
+        self._diffusion = GaussianMultinomialDiffusion(
+            num_classes=np.array([]),
+            num_numerical_features=num_numerical_features,
+            denoise_fn=self._model,
+            num_timesteps=diff_params["num_timesteps"],
+            gaussian_loss_type=diff_params.get("gaussian_loss_type", "mse"),
+            scheduler=diff_params.get("scheduler", "cosine"),
+            device=torch.device(self.device),
+        ).to(self.device)
+        self._diffusion.eval()
+
+    def sample(self, n: int) -> pd.DataFrame:
+        """Sample n synthetic rows. Returns a DataFrame with the original schema.
+
+        Note: column dtypes follow what TabDDPM emits — numerics come back as float
+        (even columns that were conceptually int, like Age), and integer-coded
+        categoricals come back as ints. Re-map to the original string vocabularies
+        upstream if the consuming code needs them.
+        """
+        self._lazy_load()
+
+        import torch
+        with torch.no_grad():
+            samples, _ = self._diffusion.sample_all(n, batch_size=min(n, 4096), ddim=False)
+        samples = samples.cpu().numpy()
+
+        n_num = self._config["num_numerical_features"]
+        cols_num = [f"num_{i}" for i in range(n_num)]
+        cols_cat = [f"cat_{i}" for i in range(samples.shape[1] - n_num)]
+        df = pd.DataFrame(samples, columns=cols_num + cols_cat)
+
+        return df
+
+
+def load_from_huggingface(repo_id: str, cache_dir: str | Path | None = None) -> TabDDPMSynthesizer:
+    """Convenience: download a published checkpoint from HuggingFace and instantiate.
+
+    Example:
+        >>> synth = load_from_huggingface("mstojkov2024/aperture-tabddpm-pima")
+        >>> df = synth.sample(500)
+    """
+    try:
+        from huggingface_hub import snapshot_download
+    except ImportError as e:
+        raise ImportError("pip install huggingface_hub to use load_from_huggingface") from e
+    local_dir = snapshot_download(repo_id=repo_id, cache_dir=cache_dir)
+    return TabDDPMSynthesizer(local_dir)


### PR DESCRIPTION
Wraps Yandex Research's TabDDPM (Kotelnikov et al. 2023) so it slots into the Aperture bench through the same Synthesizer interface as the SDV-based wrappers. The actual trained weights live on HuggingFace, not in the repo — the wrapper expects a local checkpoint_dir and lazy-loads the tab_ddpm package on first sample() call.

Files
  experimental/tabddpm/__init__.py
  experimental/tabddpm/wrapper.py     TabDDPMSynthesizer (load + sample; fit() raises
                                       by design — training lives on Sherlock GPU)
  experimental/tabddpm/upload_hf.py   --dry-run by default, --execute to push.
                                       Auto-generates a model card with the eval
                                       numbers, training config, and lit-survey
                                       pointer.
  experimental/tabddpm/README.md      training-from-scratch recipe + Sherlock srun
                                       command + sklearn API-drift patch we needed
                                       (QuantileTransformer subsample=1e9 -> int(1e9))
  experimental/tabddpm/MANIFEST.md    registry of trained checkpoints

Pima checkpoint already trained: 30k steps on A40 in 83s, gaussian_loss 0.50 -> 0.44, 50-seed CatBoost TSTR 0.840 +- 0.026 vs real-data ceiling 0.876 +- 0.004 (gap 3.6pp). On our XGBoost utility pillar, TabDDPM TSTR 0.849 vs GaussianCopula 0.651 on the same harness (gap +19.8pp).

Per the lit survey at notes/insurance_genmodels_lit_review.md, no published work applies TabDDPM specifically to insurance-fraud or claims data. fraud_oracle training queued; recipe in README.md.

The bench wiring (--tabddpm-checkpoint flag in run_trust_benchmark.py) lands in a follow-up commit once PR #1 (trust benchmark) merges to main.