### PR TITLE
Augmentation-framing copy pass across first impressions

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,13 @@
-# Team 21
-🌍 [Wiki Page](https://github.com/StanfordCS194/spr26-Team-21/wiki)
+# Aperture — Auditable synthetic data for enterprise AI
 
-Joel Sinchi  
-Marc Bernardino  
-Shani Su  
-Lea Hadzic  
-Mihajlo Stojkovic  
+> Aperture is the synthetic data **validation and generation** platform for enterprise AI teams working with sparse, sensitive, or hard-to-access data. Users describe the dataset they need to augment, ground it in their own real data, and receive both a synthetic dataset and a stakeholder-ready Trust Report covering fidelity, downstream utility, privacy, indistinguishability, and domain compliance.
+
+**We are not replacing real data — we are filling the gaps.**
+
+🌍 [Wiki Page](https://github.com/StanfordCS194/spr26-Team-21/wiki) · [Deck](./aperture_deck.pdf)
+
+## Team — *Unstructured Data*
+
+Joel Sinchi · Marc Bernardino · Shani Su · Lea Hadzic · Mihajlo Stojkovic
+
+Stanford CS 194W, Spring 2026.

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -9,7 +9,7 @@
       href="https://fonts.googleapis.com/css2?family=Instrument+Serif:ital,wght@0,400;1,400&display=swap"
       rel="stylesheet"
     />
-    <title>Aperture — Synthetic claims data for P&C insurers</title>
+    <title>Aperture — Auditable synthetic data for enterprise AI</title>
   </head>
   <body>
     <div id="root"></div>

--- a/frontend/src/components/landing/Landing.tsx
+++ b/frontend/src/components/landing/Landing.tsx
@@ -27,8 +27,9 @@ interface LandingProps {
 
 const OUTPUT_CHIPS = [
   '↓ CSV · JSONL · Parquet',
-  'Validation report',
-  'k-Anonymity checked',
+  'Trust Report · PDF',
+  'k-Anonymity · MIA-tested',
+  'Augmentation, not replacement',
 ];
 
 const MOCK_ROWS = [
@@ -63,13 +64,13 @@ function buildSteps(fileNames: string[]) {
     },
     {
       num: '02',
-      title: 'Sample synthesis',
+      title: 'Grounded synthesis',
       desc: 'Generates loss-ratio-faithful rows with Poisson frequency, lognormal severity, and preserved peril–geo correlations.',
     },
     {
       num: '03',
-      title: 'Fidelity validation',
-      desc: 'Cross-validates synthesized distributions against source bordereaux and issues an actuarial fidelity report before delivery.',
+      title: 'Trust-grade validation',
+      desc: 'Validates fidelity, downstream model utility, privacy (DCR / MIA), and indistinguishability — and ships a stakeholder-ready Trust Report.',
     },
   ];
 }

--- a/frontend/src/components/landing/PromptBox.tsx
+++ b/frontend/src/components/landing/PromptBox.tsx
@@ -53,7 +53,7 @@ export default function PromptBox({
         onChange={(e) => setPrompt(e.target.value)}
         onKeyDown={handleKeyDown}
         placeholder="e.g. 10k auto fraud claims with realistic patterns — amplify the rare cases so models can learn..."
-        aria-label="Describe the insurance dataset you want to synthesize"
+        aria-label="Describe the insurance dataset you need to augment with validated synthetic rows"
       />
       <div className="prompt-box-footer">
         <div className="prompt-meta">


### PR DESCRIPTION
Addresses the recurring demo-day feedback that visitors couldn't tell whether the wedge was generation or validation. Lands the PRD pivot ('augmentation, not replacement') on the surfaces that form first impressions: browser tab title, landing-page output chips and step titles, prompt aria-label, and the README.

No logic changes.