### PR TITLE
Surface privacy and detection pillars in the workspace

### DIFF
--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -111,6 +111,68 @@ export interface DiagnosticsReport {
   recommendations?: string[];
 }
 
+// ── Privacy ──────────────────────────────────────────────────────────────
+
+export interface PrivacyDCR {
+  median: number;
+  p5: number;
+  min: number;
+  n_exact_matches: number;
+  n_near_duplicates: number;
+  near_duplicate_pct: number;
+}
+
+export interface PrivacyNNDR {
+  median: number;
+  p5: number;
+}
+
+export interface PrivacyBaseline {
+  score: number;
+  synth_dcr_median: number;
+  random_dcr_median: number;
+}
+
+export interface MembershipInference {
+  available: boolean;
+  roc_auc: number;
+  tpr_at_1pct_fpr: number;
+  n_members: number;
+  n_nonmembers: number;
+  interpretation: string;
+}
+
+export interface PrivacyReport {
+  available: boolean;
+  n_real?: number;
+  n_synth?: number;
+  n_features?: number;
+  dcr?: PrivacyDCR;
+  nndr?: PrivacyNNDR;
+  baseline_protection?: PrivacyBaseline;
+  membership_inference?: MembershipInference | null;
+  verdict?: string;
+}
+
+// ── Detection ────────────────────────────────────────────────────────────
+
+export interface DiscriminatorResult {
+  auc: number;
+  ece: number;
+  model: string;
+}
+
+export interface DetectionReport {
+  available: boolean;
+  n_real?: number;
+  n_synth?: number;
+  n_features?: number;
+  xgboost?: DiscriminatorResult | null;
+  logreg?: DiscriminatorResult | null;
+  agreement?: string;
+  verdict?: string;
+}
+
 export interface GenerateResponse {
   session_id: string;
   row_count: number;
@@ -119,6 +181,8 @@ export interface GenerateResponse {
   filename?: string;
   validation: ValidationReportData;
   diagnostics?: DiagnosticsReport | null;
+  privacy?: PrivacyReport | null;
+  detection?: DetectionReport | null;
 }
 
 export interface ClarifyingQuestion {

--- a/frontend/src/components/workspace/AssistantMessage.tsx
+++ b/frontend/src/components/workspace/AssistantMessage.tsx
@@ -7,6 +7,8 @@ import SchemaCard from './SchemaCard';
 import SchemaInferenceProgress from './SchemaInferenceProgress';
 import ValidationReport from './ValidationReport';
 import DiagnosticsPanel from './DiagnosticsPanel';
+import PrivacyPanel from './PrivacyPanel';
+import DetectionPanel from './DetectionPanel';
 import EdgeCaseSuggestions from './EdgeCaseSuggestions';
 import ClarifyingQuestions from './ClarifyingQuestions';
 import PreviewTable from './PreviewTable';
@@ -357,6 +359,8 @@ export default function AssistantMessage({
                       </div>
                       <ValidationReport report={report} />
                       <DiagnosticsPanel diagnostics={genResult?.diagnostics} />
+                      <PrivacyPanel privacy={genResult?.privacy} />
+                      <DetectionPanel detection={genResult?.detection} />
                     </>
                   )}
                 </div>

--- a/frontend/src/components/workspace/DetectionPanel.tsx
+++ b/frontend/src/components/workspace/DetectionPanel.tsx
@@ -1,0 +1,141 @@
+import { useState } from 'react';
+import type { DetectionReport, DiscriminatorResult } from '../../api/client';
+
+interface Props {
+  detection: DetectionReport | null | undefined;
+}
+
+type Tone = 'pass' | 'warn' | 'fail' | 'info';
+
+// AUC ≈ 0.5 = indistinguishable (good). Closer to 1.0 = trivially separable (bad).
+function aucTone(auc: number): Tone {
+  if (auc < 0.6) return 'pass';
+  if (auc < 0.75) return 'warn';
+  return 'fail';
+}
+
+// Lower ECE = better-calibrated probabilities.
+function eceTone(ece: number): Tone {
+  if (ece < 0.05) return 'pass';
+  if (ece < 0.15) return 'warn';
+  return 'fail';
+}
+
+function verdictTone(verdict: string): Tone {
+  const v = verdict.toLowerCase();
+  if (v.includes('indistinguishable') || v.includes('near chance')) return 'pass';
+  if (v.includes('trivially separable') || v.includes('low fidelity')) return 'fail';
+  if (v.includes('leakage') || v.includes('separates')) return 'warn';
+  return 'info';
+}
+
+function DiscriminatorCard({
+  result,
+  fallbackLabel,
+}: {
+  result: DiscriminatorResult | null | undefined;
+  fallbackLabel: string;
+}) {
+  if (!result) {
+    return (
+      <div className="dp2-disc-card dp2-disc-unavailable">
+        <div className="dp2-disc-name">{fallbackLabel}</div>
+        <div className="dp2-disc-unavailable-text">Could not train</div>
+      </div>
+    );
+  }
+  const aTone = aucTone(result.auc);
+  const eTone = eceTone(result.ece);
+  return (
+    <div className={`dp2-disc-card dp2-disc-${aTone}`}>
+      <div className="dp2-disc-name">{result.model}</div>
+      <div className="dp2-disc-rows">
+        <div className="dp2-disc-row">
+          <span className="dp2-disc-label">AUC</span>
+          <span className={`dp2-disc-value dp2-value-${aTone}`}>{result.auc.toFixed(3)}</span>
+        </div>
+        <div className="dp2-disc-row">
+          <span className="dp2-disc-label">ECE</span>
+          <span className={`dp2-disc-value dp2-value-${eTone}`}>{result.ece.toFixed(3)}</span>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+export default function DetectionPanel({ detection }: Props) {
+  const [expanded, setExpanded] = useState(true);
+
+  if (!detection || !detection.available) {
+    return (
+      <div className="dp2-card">
+        <div className="dp2-header">
+          <span className="dp2-title">Detection (Indistinguishability)</span>
+          <span className="dp2-badge dp2-badge-info">Unavailable</span>
+        </div>
+        <div className="dp2-empty">
+          Requires real source data and a synthetic dataset of at least 50 rows each. Discriminator
+          AUC measures whether a classifier can tell real from synthetic — closer to 0.5 is better.
+        </div>
+      </div>
+    );
+  }
+
+  const verdict = detection.verdict ?? '';
+  const tone = verdictTone(verdict);
+  const xgb = detection.xgboost ?? null;
+  const lr = detection.logreg ?? null;
+
+  return (
+    <div className="dp2-card">
+      <button
+        type="button"
+        className="dp2-header dp2-header-button"
+        onClick={() => setExpanded((e) => !e)}
+        aria-expanded={expanded}
+      >
+        <span className="dp2-title">Detection (Indistinguishability)</span>
+        <span className="dp2-meta">
+          {detection.n_real?.toLocaleString() ?? '?'} real ·{' '}
+          {detection.n_synth?.toLocaleString() ?? '?'} synth · {detection.n_features ?? '?'} features
+        </span>
+        <span className={`dp2-chevron${expanded ? ' dp2-chevron-open' : ''}`}>▾</span>
+      </button>
+
+      {expanded && (
+        <div className="dp2-body">
+          {verdict && (
+            <div className={`dp2-verdict dp2-verdict-${tone}`}>
+              <span className={`dp2-badge dp2-badge-${tone}`}>Verdict</span>
+              <span className="dp2-verdict-text">{verdict}</span>
+            </div>
+          )}
+
+          <div className="dp2-discs">
+            <DiscriminatorCard result={xgb} fallbackLabel="XGBoost (non-linear)" />
+            <DiscriminatorCard result={lr} fallbackLabel="Logistic Regression (linear)" />
+          </div>
+
+          {detection.agreement && (
+            <div className="dp2-agreement">
+              <div className="dp2-section-label">Cross-model agreement</div>
+              <div className="dp2-agreement-text">{detection.agreement}</div>
+            </div>
+          )}
+
+          <div className="dp2-legend">
+            <span className="dp2-legend-item">
+              <span className="dp2-legend-swatch dp2-legend-pass" /> AUC &lt; 0.6 ≈ indistinguishable
+            </span>
+            <span className="dp2-legend-item">
+              <span className="dp2-legend-swatch dp2-legend-warn" /> 0.6–0.75 ≈ separable structure
+            </span>
+            <span className="dp2-legend-item">
+              <span className="dp2-legend-swatch dp2-legend-fail" /> &gt; 0.75 ≈ trivially separable
+            </span>
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/frontend/src/components/workspace/PrivacyPanel.tsx
+++ b/frontend/src/components/workspace/PrivacyPanel.tsx
@@ -1,0 +1,195 @@
+import { useState } from 'react';
+import type {
+  PrivacyReport,
+  MembershipInference,
+} from '../../api/client';
+
+interface Props {
+  privacy: PrivacyReport | null | undefined;
+}
+
+type Tone = 'pass' | 'warn' | 'fail' | 'info';
+
+function scoreTone(score: number): Tone {
+  if (score >= 0.8) return 'pass';
+  if (score >= 0.5) return 'warn';
+  return 'fail';
+}
+
+function dupTone(pct: number, exactCount: number): Tone {
+  if (exactCount > 0) return 'fail';
+  if (pct >= 5) return 'fail';
+  if (pct >= 1) return 'warn';
+  return 'pass';
+}
+
+function mioTone(auc: number): Tone {
+  if (auc < 0.55) return 'pass';
+  if (auc < 0.65) return 'warn';
+  return 'fail';
+}
+
+function verdictTone(verdict: string): Tone {
+  const v = verdict.toLowerCase();
+  if (v.includes('strong privacy') || v.includes('as far from real as random')) return 'pass';
+  if (v.includes('leak') || v.includes('do not share') || v.includes('exact cop')) return 'fail';
+  if (v.includes('mild') || v.includes('acceptable')) return 'warn';
+  return 'info';
+}
+
+function MetricCard({
+  label,
+  primary,
+  secondary,
+  tone,
+  caption,
+}: {
+  label: string;
+  primary: string;
+  secondary?: string;
+  tone: Tone;
+  caption?: string;
+}) {
+  return (
+    <div className={`pp-metric-card pp-metric-${tone}`}>
+      <div className="pp-metric-label">{label}</div>
+      <div className="pp-metric-primary">{primary}</div>
+      {secondary && <div className="pp-metric-secondary">{secondary}</div>}
+      {caption && <div className="pp-metric-caption">{caption}</div>}
+    </div>
+  );
+}
+
+function MIASection({ mia }: { mia: MembershipInference | null | undefined }) {
+  if (!mia || !mia.available) {
+    return (
+      <div className="pp-mia-card pp-mia-unavailable">
+        <div className="pp-mia-header">
+          <span className="pp-section-label">Membership Inference Attack</span>
+          <span className="pp-badge pp-badge-info">Unavailable</span>
+        </div>
+        <div className="pp-mia-explainer">
+          Requires a held-out set of real records the synthesizer never saw. Without it, the
+          gold-standard privacy test can't be run — distance-based metrics above are still valid.
+        </div>
+      </div>
+    );
+  }
+
+  const tone = mioTone(mia.roc_auc);
+  return (
+    <div className={`pp-mia-card pp-mia-${tone}`}>
+      <div className="pp-mia-header">
+        <span className="pp-section-label">Membership Inference Attack</span>
+        <span className={`pp-badge pp-badge-${tone}`}>AUC {mia.roc_auc.toFixed(3)}</span>
+      </div>
+      <div className="pp-mia-grid">
+        <div className="pp-mia-cell">
+          <div className="pp-mia-cell-label">TPR @ 1% FPR</div>
+          <div className="pp-mia-cell-value">{(mia.tpr_at_1pct_fpr * 100).toFixed(1)}%</div>
+        </div>
+        <div className="pp-mia-cell">
+          <div className="pp-mia-cell-label">Members</div>
+          <div className="pp-mia-cell-value">{mia.n_members.toLocaleString()}</div>
+        </div>
+        <div className="pp-mia-cell">
+          <div className="pp-mia-cell-label">Non-members</div>
+          <div className="pp-mia-cell-value">{mia.n_nonmembers.toLocaleString()}</div>
+        </div>
+      </div>
+      <div className="pp-mia-interpretation">{mia.interpretation}</div>
+    </div>
+  );
+}
+
+export default function PrivacyPanel({ privacy }: Props) {
+  const [expanded, setExpanded] = useState(true);
+
+  if (!privacy || !privacy.available) {
+    return (
+      <div className="pp-card">
+        <div className="pp-header">
+          <span className="pp-title">Privacy</span>
+          <span className="pp-badge pp-badge-info">Unavailable</span>
+        </div>
+        <div className="pp-empty">
+          Requires real source data uploaded for grounding. Privacy metrics (DCR, NNDR,
+          baseline-protection, and membership-inference) are computed against the records the
+          synthesizer was fit on.
+        </div>
+      </div>
+    );
+  }
+
+  const dcr = privacy.dcr;
+  const nndr = privacy.nndr;
+  const baseline = privacy.baseline_protection;
+  const mia = privacy.membership_inference ?? null;
+  const verdict = privacy.verdict ?? '';
+  const tone = verdictTone(verdict);
+
+  return (
+    <div className="pp-card">
+      <button
+        type="button"
+        className="pp-header pp-header-button"
+        onClick={() => setExpanded((e) => !e)}
+        aria-expanded={expanded}
+      >
+        <span className="pp-title">Privacy</span>
+        <span className="pp-meta">
+          {privacy.n_real?.toLocaleString() ?? '?'} real ·{' '}
+          {privacy.n_synth?.toLocaleString() ?? '?'} synth · {privacy.n_features ?? '?'} features
+        </span>
+        <span className={`pp-chevron${expanded ? ' pp-chevron-open' : ''}`}>▾</span>
+      </button>
+
+      {expanded && (
+        <div className="pp-body">
+          {verdict && (
+            <div className={`pp-verdict pp-verdict-${tone}`}>
+              <span className={`pp-badge pp-badge-${tone}`}>Verdict</span>
+              <span className="pp-verdict-text">{verdict}</span>
+            </div>
+          )}
+
+          <div className="pp-metric-grid">
+            {dcr && (
+              <MetricCard
+                label="DCR (median distance)"
+                primary={dcr.median.toFixed(3)}
+                secondary={`p5 = ${dcr.p5.toFixed(3)}`}
+                tone={dupTone(dcr.near_duplicate_pct, dcr.n_exact_matches)}
+                caption={
+                  dcr.n_exact_matches > 0
+                    ? `${dcr.n_exact_matches} exact match${dcr.n_exact_matches === 1 ? '' : 'es'}`
+                    : `${dcr.n_near_duplicates.toLocaleString()} near-dups (${dcr.near_duplicate_pct.toFixed(2)}%)`
+                }
+              />
+            )}
+            {nndr && (
+              <MetricCard
+                label="NNDR (nearest / 2nd-nearest)"
+                primary={nndr.median.toFixed(3)}
+                secondary={`p5 = ${nndr.p5.toFixed(3)}`}
+                tone={nndr.median >= 0.7 ? 'pass' : nndr.median >= 0.5 ? 'warn' : 'fail'}
+                caption="High ratio = synthetic sits between real records (good)"
+              />
+            )}
+            {baseline && (
+              <MetricCard
+                label="Baseline protection"
+                primary={baseline.score.toFixed(3)}
+                secondary={`synth ${baseline.synth_dcr_median.toFixed(3)} / random ${baseline.random_dcr_median.toFixed(3)}`}
+                tone={scoreTone(baseline.score)}
+                caption="1.0 = as far from real as random noise"
+              />
+            )}
+          </div>
+
+          <MIASection mia={mia} />
+        </div>
+      )}
+    </div>
+  );
+}

--- a/frontend/src/styles/workspace.css
+++ b/frontend/src/styles/workspace.css
@@ -2174,3 +2174,419 @@
   color: var(--accent);
   letter-spacing: 0.02em;
 }
+
+/* ── Privacy Panel ─────────────────────────────────────────────────────── */
+
+.pp-card {
+  margin-top: 16px;
+  background: var(--surface);
+  border: 1px solid var(--border);
+  border-radius: 12px;
+  overflow: hidden;
+}
+
+.pp-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+  padding: 14px 18px;
+  border-bottom: 1px solid var(--border);
+}
+
+.pp-header-button {
+  width: 100%;
+  background: none;
+  border: none;
+  color: inherit;
+  cursor: pointer;
+  font: inherit;
+  text-align: left;
+}
+
+.pp-header-button:hover { background: rgba(255, 255, 255, 0.02); }
+
+.pp-title {
+  font-size: 13px;
+  font-weight: 500;
+  color: var(--text);
+}
+
+.pp-meta {
+  font-size: 11px;
+  color: var(--text-muted);
+  font-family: var(--mono);
+}
+
+.pp-chevron {
+  font-size: 12px;
+  color: var(--text-dim);
+  transition: transform 0.2s ease;
+}
+
+.pp-chevron-open { transform: rotate(180deg); }
+
+.pp-badge {
+  display: inline-block;
+  padding: 2px 8px;
+  border-radius: 10px;
+  font-size: 10px;
+  letter-spacing: 0.06em;
+  font-weight: 500;
+}
+
+.pp-badge-pass { background: rgba(122, 154, 109, 0.16); color: #a4c397; }
+.pp-badge-warn { background: rgba(200, 155, 60, 0.16); color: #d8b465; }
+.pp-badge-fail { background: rgba(192, 82, 74, 0.16); color: #d97c75; }
+.pp-badge-info { background: rgba(107, 122, 143, 0.16); color: #9aa6b8; }
+
+.pp-empty {
+  padding: 18px;
+  font-size: 12px;
+  color: var(--text-muted);
+  line-height: 1.5;
+}
+
+.pp-body {
+  padding: 14px 18px 18px;
+  display: flex;
+  flex-direction: column;
+  gap: 14px;
+}
+
+.pp-verdict {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  padding: 10px 14px;
+  background: var(--bg);
+  border-radius: 6px;
+  border-left: 3px solid var(--border);
+}
+
+.pp-verdict-pass { border-left-color: #7a9a6d; }
+.pp-verdict-warn { border-left-color: #c89b3c; }
+.pp-verdict-fail { border-left-color: #c0524a; }
+.pp-verdict-info { border-left-color: #6b7a8f; }
+
+.pp-verdict-text {
+  font-size: 12px;
+  color: var(--text);
+  line-height: 1.5;
+}
+
+.pp-section-label {
+  font-size: 11px;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: var(--text-muted);
+  font-weight: 500;
+}
+
+.pp-metric-grid {
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  gap: 10px;
+}
+
+.pp-metric-card {
+  background: var(--bg);
+  border: 1px solid var(--border);
+  border-left: 3px solid var(--border);
+  padding: 12px 14px;
+  border-radius: 6px;
+}
+
+.pp-metric-pass { border-left-color: #7a9a6d; }
+.pp-metric-warn { border-left-color: #c89b3c; }
+.pp-metric-fail { border-left-color: #c0524a; }
+.pp-metric-info { border-left-color: #6b7a8f; }
+
+.pp-metric-label {
+  font-size: 10px;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: var(--text-muted);
+  font-weight: 500;
+}
+
+.pp-metric-primary {
+  font-family: var(--mono);
+  font-size: 20px;
+  margin: 6px 0 2px;
+  color: var(--text);
+}
+
+.pp-metric-secondary {
+  font-family: var(--mono);
+  font-size: 11px;
+  color: var(--text-muted);
+}
+
+.pp-metric-caption {
+  font-size: 11px;
+  color: var(--text-dim);
+  margin-top: 6px;
+  line-height: 1.4;
+}
+
+.pp-mia-card {
+  background: var(--bg);
+  border: 1px solid var(--border);
+  border-left: 3px solid var(--border);
+  padding: 14px 16px;
+  border-radius: 6px;
+}
+
+.pp-mia-pass { border-left-color: #7a9a6d; }
+.pp-mia-warn { border-left-color: #c89b3c; }
+.pp-mia-fail { border-left-color: #c0524a; }
+.pp-mia-unavailable, .pp-mia-info { border-left-color: #6b7a8f; }
+
+.pp-mia-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 10px;
+  margin-bottom: 10px;
+}
+
+.pp-mia-grid {
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  gap: 12px;
+  margin-bottom: 10px;
+}
+
+.pp-mia-cell {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+}
+
+.pp-mia-cell-label {
+  font-size: 10px;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+  color: var(--text-muted);
+}
+
+.pp-mia-cell-value {
+  font-family: var(--mono);
+  font-size: 14px;
+  color: var(--text);
+}
+
+.pp-mia-interpretation, .pp-mia-explainer {
+  font-size: 12px;
+  color: var(--text-muted);
+  line-height: 1.5;
+}
+
+/* ── Detection Panel ───────────────────────────────────────────────────── */
+
+.dp2-card {
+  margin-top: 16px;
+  background: var(--surface);
+  border: 1px solid var(--border);
+  border-radius: 12px;
+  overflow: hidden;
+}
+
+.dp2-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+  padding: 14px 18px;
+  border-bottom: 1px solid var(--border);
+}
+
+.dp2-header-button {
+  width: 100%;
+  background: none;
+  border: none;
+  color: inherit;
+  cursor: pointer;
+  font: inherit;
+  text-align: left;
+}
+
+.dp2-header-button:hover { background: rgba(255, 255, 255, 0.02); }
+
+.dp2-title {
+  font-size: 13px;
+  font-weight: 500;
+  color: var(--text);
+}
+
+.dp2-meta {
+  font-size: 11px;
+  color: var(--text-muted);
+  font-family: var(--mono);
+}
+
+.dp2-chevron {
+  font-size: 12px;
+  color: var(--text-dim);
+  transition: transform 0.2s ease;
+}
+
+.dp2-chevron-open { transform: rotate(180deg); }
+
+.dp2-badge {
+  display: inline-block;
+  padding: 2px 8px;
+  border-radius: 10px;
+  font-size: 10px;
+  letter-spacing: 0.06em;
+  font-weight: 500;
+}
+
+.dp2-badge-pass { background: rgba(122, 154, 109, 0.16); color: #a4c397; }
+.dp2-badge-warn { background: rgba(200, 155, 60, 0.16); color: #d8b465; }
+.dp2-badge-fail { background: rgba(192, 82, 74, 0.16); color: #d97c75; }
+.dp2-badge-info { background: rgba(107, 122, 143, 0.16); color: #9aa6b8; }
+
+.dp2-empty {
+  padding: 18px;
+  font-size: 12px;
+  color: var(--text-muted);
+  line-height: 1.5;
+}
+
+.dp2-body {
+  padding: 14px 18px 18px;
+  display: flex;
+  flex-direction: column;
+  gap: 14px;
+}
+
+.dp2-verdict {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  padding: 10px 14px;
+  background: var(--bg);
+  border-radius: 6px;
+  border-left: 3px solid var(--border);
+}
+
+.dp2-verdict-pass { border-left-color: #7a9a6d; }
+.dp2-verdict-warn { border-left-color: #c89b3c; }
+.dp2-verdict-fail { border-left-color: #c0524a; }
+.dp2-verdict-info { border-left-color: #6b7a8f; }
+
+.dp2-verdict-text {
+  font-size: 12px;
+  color: var(--text);
+  line-height: 1.5;
+}
+
+.dp2-section-label {
+  font-size: 11px;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: var(--text-muted);
+  font-weight: 500;
+}
+
+.dp2-discs {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 12px;
+}
+
+.dp2-disc-card {
+  background: var(--bg);
+  border: 1px solid var(--border);
+  border-left: 3px solid var(--border);
+  padding: 12px 14px;
+  border-radius: 6px;
+}
+
+.dp2-disc-pass { border-left-color: #7a9a6d; }
+.dp2-disc-warn { border-left-color: #c89b3c; }
+.dp2-disc-fail { border-left-color: #c0524a; }
+.dp2-disc-unavailable { border-left-color: #6b7a8f; }
+
+.dp2-disc-name {
+  font-size: 11px;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+  color: var(--text-muted);
+  font-weight: 500;
+  margin-bottom: 10px;
+}
+
+.dp2-disc-rows {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+
+.dp2-disc-row {
+  display: flex;
+  justify-content: space-between;
+  align-items: baseline;
+}
+
+.dp2-disc-label {
+  font-size: 11px;
+  color: var(--text-muted);
+}
+
+.dp2-disc-value {
+  font-family: var(--mono);
+  font-size: 14px;
+  color: var(--text);
+}
+
+.dp2-value-pass { color: #a4c397; }
+.dp2-value-warn { color: #d8b465; }
+.dp2-value-fail { color: #d97c75; }
+
+.dp2-disc-unavailable-text {
+  font-size: 12px;
+  color: var(--text-dim);
+  font-style: italic;
+}
+
+.dp2-agreement {
+  padding: 10px 14px;
+  background: var(--bg);
+  border-radius: 6px;
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+
+.dp2-agreement-text {
+  font-size: 12px;
+  color: var(--text-muted);
+  line-height: 1.5;
+}
+
+.dp2-legend {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 14px;
+  font-size: 10px;
+  color: var(--text-dim);
+}
+
+.dp2-legend-item {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+}
+
+.dp2-legend-swatch {
+  width: 8px;
+  height: 8px;
+  border-radius: 2px;
+}
+
+.dp2-legend-pass { background: #7a9a6d; }
+.dp2-legend-warn { background: #c89b3c; }
+.dp2-legend-fail { background: #c0524a; }


### PR DESCRIPTION
_No backend changes._

Privacy (DCR, NNDR, Baseline Protection, MIA) and Detection (XGBoost + LogReg discriminators) were already computed by /api/generate but invisible in the live workspace — users had to open the Trust Report HTML to see them.

**PrivacyPanel**
- Verdict pill at top (driven by privacy.verdict — strong / mild / leak)
- Three metric cards: DCR median + near-duplicate count, NNDR median + p5, Baseline Protection score
- Dedicated MIA section with ROC-AUC, TPR @ 1% FPR, members vs non-members count, and the interpretation string. Renders an 'Unavailable' state when no holdout was provided.

**DetectionPanel**
- Verdict pill at top
- Two discriminator cards side-by-side (XGBoost non-linear vs LogReg linear) showing AUC and ECE, color-coded against the 0.5 / 0.6 / 0.75 thresholds
- Cross-model agreement narrative (flags non-linear leakage when XGBoost separates but LR can't)
- Legend explaining the AUC interpretation