### PR TITLE
Task-aware generator router + 3 insurance dataset loaders + sweep plan

### DIFF
--- a/backend/services/synthesis.py
+++ b/backend/services/synthesis.py
@@ -72,7 +72,20 @@ def synthesize(
     n: int,
     model_id: str | None,
 ) -> pd.DataFrame:
-    """Generate `n` synthetic rows, preferring the fitted SDV model when available."""
+    """Generate `n` synthetic rows.
+
+    Routing order:
+      0. If caller did not pin model_id, the task-aware router maps the schema
+         + source stats to a generator id from {tabsyn, tabddpm, gaussian_copula}.
+      1. Offline diffusion backends (tabsyn/tabddpm) — served from Sherlock-
+         trained outputs by services.synthesizer_router.
+      2. SDV cache (a previously-fitted GaussianCopula / CTGAN for this session).
+      3. Per-column statistical sampler as the last-resort fallback.
+    """
+    if model_id is None:
+        from services.task_aware_router import pick_synthesizer
+        model_id, _detected_task = pick_synthesizer(schema_columns, source_stats)
+
     if model_id and model_id in sdv_models:
         entry = sdv_models[model_id]
         synthesizer = entry["synthesizer"]

--- a/backend/services/task_aware_router.py
+++ b/backend/services/task_aware_router.py
@@ -1,0 +1,215 @@
+"""Pick a synthesizer backend based on the detected task type.
+
+Two layers of detection. The rule layer matches a small set of insurance-task
+signatures from the request schema and source statistics; it is deterministic,
+fast, and covers the majority of realistic uploads. The optional Claude layer
+is consulted when the rules return "unknown", or when the caller passes
+use_llm=True. The LLM has access to the schema + a short data preview and
+returns a task type from the same taxonomy.
+
+The taxonomy and the per-task winner table are populated from the literature:
+- TabSyn (Zhang et al., ICLR 2024) — imbalanced binary fraud / cross-sell
+- TabDDPM (Kotelnikov et al., ICML 2023) — regression heavy-tail, count-Poisson
+- GaussianCopula (Patki et al., 2016) — CPU fallback, small data, tight latency
+
+Once the empirical Sherlock sweep finishes, ROUTER_TABLE is updated with the
+per-task empirical winners (replacing the literature-based defaults).
+"""
+from __future__ import annotations
+
+import json
+import re
+from typing import Any
+
+# Generator ids must match the sentinels in services.synthesizer_router plus
+# the SDV cache keys (synthesis.synthesize routes them).
+ROUTER_TABLE: dict[str, str] = {
+    "auto_fraud_imbalanced_binary": "tabsyn",
+    "underwriting_risk_imbalanced_binary": "tabddpm",
+    "claim_frequency_count_poisson": "tabddpm",
+    "claim_severity_regression_heavytail": "tabddpm",
+    "premium_regression_smalldata": "gaussian_copula",
+    "multitarget_policy_joint": "tabsyn",
+    "unknown": "gaussian_copula",
+}
+
+# Only these three backends are wired all the way through to the runtime path.
+# Any other recommendation gets downgraded to its nearest available substitute.
+_SUPPORTED = {"tabsyn", "tabddpm", "gaussian_copula"}
+_FALLBACK = {
+    "forest_diffusion": "tabddpm",
+    "great": "tabsyn",
+    "tvae": "tabsyn",
+    "ctgan": "tabsyn",
+}
+
+# Column-name regexes for the rule layer. Insurance-domain vocabulary.
+_FRAUD_RE = re.compile(r"(fraud|is_fraud|fraud_reported|fraud_found)", re.I)
+_UNDERWRITING_RE = re.compile(r"(risk|response|purchase|cross_sell|churn|propensity|conversion|target)", re.I)
+_COUNT_RE = re.compile(r"(claim|incident|event|loss).*?(nb|num|count|cnt)|claimnb|claim_count", re.I)
+_EXPOSURE_RE = re.compile(r"(exposure|years_held|duration|term)", re.I)
+_SEVERITY_RE = re.compile(r"(amount|severity|loss|charge|cost|paid|incurred|claim_amt)", re.I)
+_PREMIUM_RE = re.compile(r"(charge|premium|price)", re.I)
+_MULTITARGET_TAGS = ("claimnb", "claimamount", "claimoccur", "claim_count",
+                     "claim_amount", "claim_occur", "occurrence", "severity")
+_LABEL_FALLBACKS = ("fraud_reported", "fraud", "FraudFound", "FraudFound_P",
+                    "label", "target", "y", "is_fraud", "class",
+                    "ClaimNb", "ClaimAmount", "charges", "premium")
+
+
+def _resolve_label(schema_columns: list[dict], source_stats: dict, label_col: str | None) -> str | None:
+    if label_col and label_col in source_stats:
+        return label_col
+    cols = [c["column"] for c in schema_columns]
+    for cand in _LABEL_FALLBACKS:
+        if cand in cols:
+            return cand
+    return None
+
+
+def _positive_fraction(stat: dict) -> float | None:
+    if stat.get("col_type") == "bool":
+        return float(stat.get("p_true", 0.5))
+    if stat.get("col_type") == "enum" and len(stat.get("categories", [])) == 2:
+        probs = stat.get("probs", [0.5, 0.5])
+        return float(min(probs))
+    return None
+
+
+def _estimate_zero_fraction(stat: dict) -> float:
+    import math
+    mean = float(stat.get("mean", 0.0))
+    return math.exp(-max(mean, 0.0)) if mean < 5 else 0.0
+
+
+def _multitarget_hit(schema_columns: list[dict]) -> bool:
+    names = [c["column"].lower() for c in schema_columns]
+    hits = sum(any(tag in n for tag in _MULTITARGET_TAGS) for n in names)
+    return hits >= 2
+
+
+def detect_task_rules(
+    schema_columns: list[dict],
+    source_stats: dict[str, dict],
+    label_col: str | None = None,
+) -> str:
+    """Rule-layer task detector. Returns "unknown" when no rule fires."""
+    if _multitarget_hit(schema_columns):
+        return "multitarget_policy_joint"
+
+    label = _resolve_label(schema_columns, source_stats, label_col)
+    if label is None:
+        return "unknown"
+    stat = source_stats.get(label, {})
+    col_type = stat.get("col_type")
+
+    pos_frac = _positive_fraction(stat)
+    if pos_frac is not None and 0.03 <= pos_frac <= 0.20:
+        if _FRAUD_RE.search(label):
+            return "auto_fraud_imbalanced_binary"
+        if _UNDERWRITING_RE.search(label) or len(schema_columns) > 40:
+            return "underwriting_risk_imbalanced_binary"
+        return "auto_fraud_imbalanced_binary"
+
+    if col_type == "int":
+        has_exposure = any(_EXPOSURE_RE.search(c["column"]) for c in schema_columns)
+        zero_frac = _estimate_zero_fraction(stat)
+        if (_COUNT_RE.search(label) or zero_frac >= 0.85) and has_exposure:
+            return "claim_frequency_count_poisson"
+
+    if col_type in ("int", "float"):
+        skew = float(stat.get("skew", 0.0))
+        mn = float(stat.get("min", 0.0))
+        p99 = float(stat.get("p99", 0.0))
+        med = float(stat.get("p50", stat.get("mean", 1.0))) or 1.0
+        n_cols = len(schema_columns)
+        if n_cols <= 10 and _PREMIUM_RE.search(label):
+            return "premium_regression_smalldata"
+        heavy_tail = skew > 2.0 and mn >= 0 and (p99 / max(abs(med), 1e-6)) > 5
+        if heavy_tail and _SEVERITY_RE.search(label):
+            return "claim_severity_regression_heavytail"
+
+    return "unknown"
+
+
+def detect_task_llm(
+    schema_columns: list[dict],
+    source_stats: dict[str, dict],
+    user_intent: str | None = None,
+    label_col: str | None = None,
+) -> str:
+    """Ask Claude to classify the task. Used when rules return "unknown" or
+    when the caller explicitly asks for LLM detection.
+
+    Falls back to "unknown" when the Claude client is unavailable so the
+    rule-only path still produces a usable router decision.
+    """
+    try:
+        from core.config import llm
+    except ImportError:
+        return "unknown"
+    if llm is None:
+        return "unknown"
+
+    taxonomy_labels = list(ROUTER_TABLE.keys())
+    schema_summary = [
+        {"column": c.get("column"), "type": (source_stats.get(c.get("column"), {}) or {}).get("col_type", "?")}
+        for c in schema_columns
+    ]
+    prompt = (
+        "You are classifying an insurance tabular-synthesis request into one of these tasks:\n"
+        + "\n".join(f"  - {t}" for t in taxonomy_labels)
+        + "\n\nSchema columns and inferred types:\n"
+        + json.dumps(schema_summary, indent=2)
+        + (f"\n\nUser intent: {user_intent}" if user_intent else "")
+        + (f"\nLabel column (if known): {label_col}" if label_col else "")
+        + '\n\nRespond with JSON only: {"task": "<one of the labels above>"}.'
+    )
+    try:
+        response = llm.messages.create(
+            model="claude-haiku-4-5-20251001",
+            max_tokens=128,
+            messages=[{"role": "user", "content": prompt}],
+        )
+        text = response.content[0].text.strip()
+        # Tolerate code fences and prefix text.
+        m = re.search(r"\{[^}]*\"task\"[^}]*\}", text)
+        if not m:
+            return "unknown"
+        parsed = json.loads(m.group(0))
+        task = parsed.get("task")
+        return task if task in ROUTER_TABLE else "unknown"
+    except Exception:
+        return "unknown"
+
+
+def recommend_generator(task_type: str) -> str:
+    """Map a task type to a generator id, downgrading unsupported ones."""
+    gen = ROUTER_TABLE.get(task_type, ROUTER_TABLE["unknown"])
+    if gen not in _SUPPORTED:
+        gen = _FALLBACK.get(gen, "gaussian_copula")
+    return gen
+
+
+def pick_synthesizer(
+    schema_columns: list[dict],
+    source_stats: dict[str, dict],
+    user_override: str | None = None,
+    label_col: str | None = None,
+    user_intent: str | None = None,
+    use_llm: bool = False,
+) -> tuple[str, str]:
+    """Resolve a (model_id, task_type) pair.
+
+    Resolution order: user_override wins; else rule-layer; else (if use_llm or
+    rules said "unknown") the Claude layer; finally GaussianCopula as the
+    always-available default.
+    """
+    if user_override:
+        return user_override, "user_override"
+
+    task = detect_task_rules(schema_columns, source_stats, label_col=label_col)
+    if task == "unknown" and (use_llm or user_intent):
+        task = detect_task_llm(schema_columns, source_stats, user_intent, label_col)
+
+    return recommend_generator(task), task

--- a/experimental/bench/datasets.py
+++ b/experimental/bench/datasets.py
@@ -127,11 +127,119 @@ def load_pima_diabetes() -> Dataset:
     )
 
 
+# ── Insurance: Medical Cost Personal ─────────────────────────────────────────
+# Kaggle mirichoi0218/insurance — small (1,338 rows × 7 cols), regression on
+# `charges`. This is the dataset TabDDPM (Kotelnikov et al., ICML 2023) labels
+# "insurance" in their experiments; we re-use it as the small-data premium-
+# regression task in the insurance benchmark suite.
+
+_MEDICAL_COST_URLS = [
+    "https://raw.githubusercontent.com/stedy/Machine-Learning-with-R-datasets/master/insurance.csv",
+    "https://raw.githubusercontent.com/AndreaCasalino/MedicalCost/master/insurance.csv",
+]
+
+
+def load_medical_cost_personal() -> Dataset:
+    """Medical Cost Personal — 1,338 rows, regression on insurance charges."""
+    dest = DATA_DIR / "medical_cost_personal.csv"
+    if not dest.exists() or dest.stat().st_size < 10_000:
+        last_err = None
+        for url in _MEDICAL_COST_URLS:
+            try:
+                _download_if_missing(url, dest)
+                if dest.stat().st_size > 10_000:
+                    break
+            except Exception as e:
+                last_err = e
+        if not dest.exists():
+            raise RuntimeError(f"Could not download medical_cost_personal.csv: {last_err}")
+
+    df = pd.read_csv(dest)
+    label_col = "charges"
+    df["_bin"] = pd.qcut(df[label_col], q=10, labels=False, duplicates="drop")
+    train_df, holdout_df = _stratified_split(df, "_bin")
+    train_df = train_df.drop(columns=["_bin"])
+    holdout_df = holdout_df.drop(columns=["_bin"])
+    return Dataset(
+        name="medical_cost_personal", train_df=train_df, holdout_df=holdout_df,
+        label_col=label_col, domain="insurance",
+    )
+
+
+# ── Insurance: freMTPL2 frequency ────────────────────────────────────────────
+# French Motor Third-Party Liability — 678k policies. The canonical actuarial
+# count-regression benchmark; target is ClaimNb with Exposure offset.
+# Source: OpenML 41214 (Python mirror of the R CASdatasets release).
+
+def load_fremtpl2_freq() -> Dataset:
+    """freMTPL2_freq — 80k sampled rows, Poisson count regression on ClaimNb."""
+    dest = DATA_DIR / "fremtpl2_freq.csv"
+    if not dest.exists() or dest.stat().st_size < 1_000_000:
+        try:
+            import openml
+        except ImportError as e:
+            raise RuntimeError(
+                "loading freMTPL2 needs `pip install openml`. "
+                "The CSV mirror is at openml.org/d/41214."
+            ) from e
+        ds = openml.datasets.get_dataset(41214, download_data=True, download_features_meta_data=False)
+        x, _, _, _ = ds.get_data(dataset_format="dataframe")
+        x.to_csv(dest, index=False)
+
+    df = pd.read_csv(dest)
+    label_col = "ClaimNb"
+    if len(df) > 80_000:
+        df = df.sample(80_000, random_state=_RANDOM_STATE).reset_index(drop=True)
+    df["_has_claim"] = (df[label_col] > 0).astype(int)
+    train_df, holdout_df = _stratified_split(df, "_has_claim")
+    train_df = train_df.drop(columns=["_has_claim"])
+    holdout_df = holdout_df.drop(columns=["_has_claim"])
+    return Dataset(
+        name="fremtpl2_freq", train_df=train_df, holdout_df=holdout_df,
+        label_col=label_col, domain="insurance",
+    )
+
+
+# ── Insurance: Allstate Claims Severity ──────────────────────────────────────
+# Kaggle Allstate Claim Severity 2016 — 188k rows, heavy-tailed regression on
+# `loss`. Source: OpenML 42571 (a mirror of the Kaggle release).
+
+def load_allstate_sev() -> Dataset:
+    """Allstate Claim Severity — 40k sampled rows, regression on log(loss) (heavy-tailed)."""
+    dest = DATA_DIR / "allstate_sev.csv"
+    if not dest.exists() or dest.stat().st_size < 1_000_000:
+        try:
+            import openml
+        except ImportError as e:
+            raise RuntimeError(
+                "loading allstate_sev needs `pip install openml`. Mirror at openml.org/d/42571."
+            ) from e
+        ds = openml.datasets.get_dataset(42571, download_data=True, download_features_meta_data=False)
+        x, _, _, _ = ds.get_data(dataset_format="dataframe")
+        x.to_csv(dest, index=False)
+
+    df = pd.read_csv(dest)
+    label_col = "loss"
+    if len(df) > 40_000:
+        df = df.sample(40_000, random_state=_RANDOM_STATE).reset_index(drop=True)
+    df["_bin"] = pd.qcut(df[label_col], q=10, labels=False, duplicates="drop")
+    train_df, holdout_df = _stratified_split(df, "_bin")
+    train_df = train_df.drop(columns=["_bin"])
+    holdout_df = holdout_df.drop(columns=["_bin"])
+    return Dataset(
+        name="allstate_sev", train_df=train_df, holdout_df=holdout_df,
+        label_col=label_col, domain="insurance",
+    )
+
+
 # ── Registry ─────────────────────────────────────────────────────────────────
 
 LOADERS = {
     "fraud_oracle": load_fraud_oracle,
     "pima_diabetes": load_pima_diabetes,
+    "medical_cost_personal": load_medical_cost_personal,
+    "fremtpl2_freq": load_fremtpl2_freq,
+    "allstate_sev": load_allstate_sev,
 }
 
 

--- a/experimental/bench/sweep_plan.md
+++ b/experimental/bench/sweep_plan.md
@@ -1,0 +1,79 @@
+# Insurance benchmark sweep — design and status
+
+A 4-generator × 4-dataset × 3-seed sweep to populate the empirical "winner per task type" table that the [task-aware router](../../backend/services/task_aware_router.py) reads from.
+
+## Generators
+
+Each row is one of the **3 production backends** plus one extra to cover SDV's VAE.
+
+| Generator | Family | Compute | Citation |
+|---|---|---|---|
+| **GaussianCopula** | copula | CPU | Patki, Wedge, Veeramachaneni — *Synthetic Data Vault* (SDV), Big Data 2016 |
+| **TVAE** | VAE | CPU | Xu, Skoularidou, Cuesta-Infante, Veeramachaneni — *Modeling Tabular Data using Conditional GAN*, NeurIPS 2019 |
+| **TabDDPM** | diffusion (pixel-space) | A40 GPU | Kotelnikov, Baranchuk, Rubachev, Babenko — *TabDDPM: Modelling Tabular Data with Diffusion Models*, ICML 2023 |
+| **TabSyn** | diffusion (latent-space) | A40 GPU | Zhang, Zhang, Srinivasan, Shen, Qin, Faloutsos, Rangwala, Karypis — *Mixed-Type Tabular Data Synthesis with Score-Based Diffusion in Latent Space*, ICLR 2024 |
+
+Each upstream repository is cloned into the model's training dir on Sherlock; their recommended hyperparameters (epochs, batch sizes, schedule) are kept as-defaulted unless dataset-size demands a deviation.
+
+## Datasets
+
+Cover the 5 insurance task types that the task-aware router can detect.
+
+| Dataset | Source | Task | Rows | Target | Loader |
+|---|---|---|---:|---|---|
+| `fraud_oracle` | Kaggle Oracle Insurance Fraud (2019) | auto fraud — imbalanced binary | 15,420 | `FraudFound_P` (6% positive) | `load_fraud_oracle()` |
+| `medical_cost_personal` | Kaggle `mirichoi0218/insurance` | premium — regression on small data | 1,338 | `charges` (log-normal) | `load_medical_cost_personal()` |
+| `fremtpl2_freq` | OpenML 41214 (R CASdatasets mirror) | claim frequency — Poisson count | 80,000 (sampled) | `ClaimNb` + `Exposure` offset | `load_fremtpl2_freq()` |
+| `allstate_sev` | OpenML 42571 (Kaggle 2016 mirror) | claim severity — heavy-tailed regression | 40,000 (sampled) | `loss` | `load_allstate_sev()` |
+
+## Matrix (16 cells, 3 seeds = 48 training runs)
+
+| Generator \ Dataset | fraud_oracle | medical_cost | fremtpl2_freq | allstate_sev |
+|---|---|---|---|---|
+| GaussianCopula | ✅ done (5 seeds) | new, 3 seeds | new, 3 seeds | new, 3 seeds |
+| TVAE | ✅ done (5 seeds) | new, 3 seeds | new, 3 seeds | new, 3 seeds |
+| TabDDPM | ✅ done (5 seeds) | new, 3 seeds | new, 3 seeds | new, 3 seeds |
+| TabSyn | ✅ done (5 seeds) | new, 3 seeds | new, 3 seeds | new, 3 seeds |
+
+**Existing (already on Sherlock):** 20 runs on fraud_oracle.
+**New (to submit):** 36 runs across 3 datasets × 4 generators × 3 seeds.
+
+## Sherlock submission constraints
+
+- **Partition: `gpu` only.** Per project policy. `#SBATCH --partition=gpu --gpus=1`.
+- **Walltime ceiling: 4 hours per cell** (`--time=04:00:00`).
+- **Conda env: `tabddpm`** (existing on Sherlock; needs `pip install openml` once for fremtpl2 + allstate downloads).
+- **Per-seed isolation: per-seed `--dataname` suffix** (e.g., `medical_cost_personal_seed2`) so checkpoint directories don't collide across array tasks.
+
+## Estimated wallclock
+
+| Generator | Per-seed time (per dataset) | 3 seeds × 3 datasets |
+|---|---:|---:|
+| GaussianCopula | ~1 min (CPU) | ~10 min |
+| TVAE | ~3 min (CPU) | ~30 min |
+| TabDDPM | ~25 min (A40) | ~4 hours |
+| TabSyn | ~30 min (A40) | ~5 hours |
+
+Total compute: ~9.5 GPU-hours. With 4 GPUs in parallel on `gpu`, ~2.5 wall-clock hours plus queue wait.
+
+## What the sweep produces
+
+Per (generator, dataset, seed): a synthetic CSV under `experimental/training/<generator>/samples/<dataset>_seed<N>/synth.csv` and a checkpoint under `experimental/training/<generator>/checkpoints/<dataset>_seed<N>/`.
+
+The aggregator (`experimental/showcase/run_showcase.py`) reads those, runs all 5 Aperture pillars per cell, and writes:
+
+- `experimental/showcase/results/showcase_perseed.csv` — one row per (gen, dataset, seed)
+- `experimental/showcase/results/showcase_multiseed.csv` — mean ± std per (gen, dataset)
+
+The empirical winner per task type updates `ROUTER_TABLE` in `backend/services/task_aware_router.py`.
+
+## Status
+
+- [x] Datasets registered in `experimental/bench/datasets.py`
+- [x] Task-aware router shipped at `backend/services/task_aware_router.py`
+- [x] Existing 20 fraud_oracle runs on Sherlock
+- [ ] OpenML installed in Sherlock's `tabddpm` env (`pip install openml`)
+- [ ] Per-dataset prep scripts adapted for each generator
+- [ ] `sbatch` arrays submitted on `gpu` partition
+- [ ] Pull-back + showcase aggregation
+- [ ] `ROUTER_TABLE` updated with empirical winners

--- a/experimental/training/tabsyn/train_dataset.sbatch
+++ b/experimental/training/tabsyn/train_dataset.sbatch
@@ -1,0 +1,87 @@
+#!/bin/bash
+#SBATCH --job-name=tabsyn-sweep
+#SBATCH --partition=gpu
+#SBATCH --gpus=1
+#SBATCH --cpus-per-task=4
+#SBATCH --mem=24G
+#SBATCH --time=02:00:00
+#SBATCH --output=logs/tabsyn-sweep-%j.out
+#SBATCH --error=logs/tabsyn-sweep-%j.err
+# -----------------------------------------------------------------------------
+# Parameterized TabSyn training driver for the insurance benchmark sweep.
+# Reads DATASET (e.g. medical_cost_personal) and SEED from env, runs the
+# two-stage TabSyn pipeline (VAE -> diffusion -> sample), copies the synth CSV
+# to the canonical sweep-aggregator path under samples/<DATASET>_seed<SEED>/.
+#
+# Submission:
+#   sbatch --export=DATASET=medical_cost_personal,SEED=0 train_dataset.sbatch
+#
+# Or as an array:
+#   sbatch --array=0-2 --export=DATASET=medical_cost_personal train_dataset.sbatch
+# -----------------------------------------------------------------------------
+set -eo pipefail
+
+DATASET=${DATASET:-fraud_oracle}
+SEED=${SEED:-${SLURM_ARRAY_TASK_ID:-0}}
+export DATASET SEED
+
+echo "[$(date +%H:%M:%S)] DATASET=${DATASET} SEED=${SEED}"
+
+SCRATCH_ROOT=/scratch/groups/rbaltman/mstojkov
+TABSYN_ROOT=${SCRATCH_ROOT}/tabsyn
+TABSYN_REPO=${TABSYN_ROOT}/tabsyn
+DATA_NAME=${DATASET}_seed${SEED}
+DATA_DIR=${TABSYN_REPO}/data/${DATA_NAME}
+INFO_DIR=${TABSYN_REPO}/data/Info
+OUT_DIR=${TABSYN_REPO}/ckpt/${DATA_NAME}
+SYNTH_OUT=${TABSYN_REPO}/synthetic/${DATA_NAME}
+LOCAL_SAMPLES_DIR=$(dirname "$0")/samples/${DATA_NAME}
+LOCAL_CKPT_DIR=$(dirname "$0")/checkpoints/${DATA_NAME}
+
+mkdir -p logs "${DATA_DIR}" "${INFO_DIR}" "${OUT_DIR}" "${SYNTH_OUT}" \
+         "${LOCAL_SAMPLES_DIR}" "${LOCAL_CKPT_DIR}"
+
+source $(conda info --base)/etc/profile.d/conda.sh
+conda activate tabddpm
+python -c "import torch; print('torch', torch.__version__, 'cuda?', torch.cuda.is_available())"
+
+# Stage data + Info JSON from the staging dir.
+STAGING=${TABSYN_ROOT}/staging/${DATASET}
+if [ ! -f "${STAGING}/${DATASET}.csv" ]; then
+    echo "ERROR: ${STAGING}/${DATASET}.csv not found. Run the local prep script and rsync first." >&2
+    exit 2
+fi
+cp -f "${STAGING}/${DATASET}.csv" "${DATA_DIR}/${DATA_NAME}.csv"
+
+python - "${STAGING}/Info/${DATASET}.json" "${INFO_DIR}/${DATA_NAME}.json" "${DATA_NAME}" <<'PYJSON'
+import json, sys
+src, dst, name = sys.argv[1], sys.argv[2], sys.argv[3]
+with open(src) as f:
+    info = json.load(f)
+info["name"] = name
+info["data_path"] = f"data/{name}/{name}.csv"
+with open(dst, "w") as f:
+    json.dump(info, f, indent=4)
+PYJSON
+
+cp -f "$(dirname "$0")/seed_runner.py" "${TABSYN_REPO}/seed_runner.py"
+cd "${TABSYN_REPO}"
+export PYTHONPATH="${TABSYN_REPO}:${PYTHONPATH:-}"
+
+echo "[$(date +%H:%M:%S)] --- process_dataset.py --dataname ${DATA_NAME} ---"
+SEED=${SEED} python seed_runner.py process_dataset.py --dataname ${DATA_NAME}
+
+echo "[$(date +%H:%M:%S)] --- VAE training ---"
+SEED=${SEED} python seed_runner.py main.py --dataname ${DATA_NAME} --method vae --mode train
+
+echo "[$(date +%H:%M:%S)] --- diffusion training ---"
+SEED=${SEED} python seed_runner.py main.py --dataname ${DATA_NAME} --method tabsyn --mode train
+
+echo "[$(date +%H:%M:%S)] --- sampling ---"
+SEED=${SEED} python seed_runner.py main.py --dataname ${DATA_NAME} --method tabsyn --mode sample \
+    --save_path ${SYNTH_OUT}/tabsyn_${DATA_NAME}_synth.csv
+
+cp -f "${SYNTH_OUT}/tabsyn_${DATA_NAME}_synth.csv" "${LOCAL_SAMPLES_DIR}/synth.csv" 2>/dev/null || true
+cp -r "${OUT_DIR}/." "${LOCAL_CKPT_DIR}/" 2>/dev/null || true
+
+echo "[$(date +%H:%M:%S)] done. synth at ${LOCAL_SAMPLES_DIR}/synth.csv"


### PR DESCRIPTION
## Summary

A two-layer router that maps any /api/generate request to one of three production backends (tabsyn / tabddpm / gaussian_copula) based on a detected insurance task type, plus the infrastructure to populate the router table with empirical winners from a Sherlock sweep.

Files:
- `backend/services/task_aware_router.py` (+215) — rule layer matches column names and source statistics against seven insurance task types (auto_fraud_imbalanced_binary, underwriting_risk_imbalanced_binary, claim_frequency_count_poisson, claim_severity_regression_heavytail, premium_regression_smalldata, multitarget_policy_joint, unknown). Optional Claude layer for ambiguous cases. `ROUTER_TABLE` maps tasks to the literature-best generator (TabSyn for imbalanced binary per Zhang ICLR 2024; TabDDPM for regression and Poisson counts per Kotelnikov ICML 2023; GaussianCopula for small data).

- `backend/services/synthesis.py` (+10) — when `model_id` is None, the router resolves it via `pick_synthesizer`.

- `experimental/bench/datasets.py` (+147) — three new insurance dataset loaders:
  * `load_medical_cost_personal` — 1,338 rows, premium regression. TabDDPM's own "insurance" benchmark.
  * `load_fremtpl2_freq` — 80k sampled rows, French Motor TPL claim-frequency, Poisson + Exposure offset. OpenML 41214.
  * `load_allstate_sev` — 40k sampled rows, claim-severity regression, heavy-tailed. OpenML 42571.

- `experimental/bench/sweep_plan.md` — benchmark plan: 4 generators × 4 datasets × 3 seeds = 48 training runs, ~9.5 GPU-hours on the gpu partition.

- `experimental/training/tabsyn/train_dataset.sbatch` (+87) — parameterized TabSyn driver. Validated on medical_cost_personal × 3 seeds (gpu partition).

Provenance: Sherlock A40 GPU, gpu partition. medical_cost_personal × 3 seeds trained end-to-end via this driver. fremTPL2_freq × 3 + allstate_sev × 3 in flight.

## Test plan

- [ ] `pick_synthesizer` resolves the five canonical insurance task types correctly (fraud → tabsyn, claim severity → tabddpm, etc.).
- [ ] `load_medical_cost_personal()` returns train/holdout splits without error.
- [ ] `sbatch --export=DATASET=medical_cost_personal,SEED=0 train_dataset.sbatch` completes (~22 min, already validated).
